### PR TITLE
Use markdown TODO list items for file links in markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,15 @@ After pressing **Enter**:
 3 repos · 6 files · 7 matches selected
 
 - **fulll/auth-service** (2 matches)
-  - [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
-  - [tests/unit/featureFlags.test.ts:1:8](https://github.com/fulll/auth-service/blob/main/tests/unit/featureFlags.test.ts#L1)
+  - [ ] [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
+  - [ ] [tests/unit/featureFlags.test.ts:1:8](https://github.com/fulll/auth-service/blob/main/tests/unit/featureFlags.test.ts#L1)
 - **fulll/billing-api**
-  - [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
-  - [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
-  - [src/routes/subscriptions.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/subscriptions.ts#L1)
+  - [ ] [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
+  - [ ] [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
+  - [ ] [src/routes/subscriptions.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/subscriptions.ts#L1)
 - **fulll/frontend-app**
-  - [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
-  - [src/components/Dashboard.tsx:4:3](https://github.com/fulll/frontend-app/blob/main/src/components/Dashboard.tsx#L4)
+  - [ ] [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
+  - [ ] [src/components/Dashboard.tsx:4:3](https://github.com/fulll/frontend-app/blob/main/src/components/Dashboard.tsx#L4)
 
 <details>
 <summary>replay command</summary>
@@ -209,13 +209,13 @@ $ CI=true github-code-search "useFeatureFlag" --org fulll
 3 repos · 5 matches selected
 
 - **fulll/auth-service**
-  - [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
-  - [tests/unit/featureFlags.test.ts:1:8](https://github.com/fulll/auth-service/blob/main/tests/unit/featureFlags.test.ts#L1)
+  - [ ] [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
+  - [ ] [tests/unit/featureFlags.test.ts:1:8](https://github.com/fulll/auth-service/blob/main/tests/unit/featureFlags.test.ts#L1)
 - **fulll/billing-api**
-  - [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
-  - [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
+  - [ ] [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
+  - [ ] [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
 - **fulll/frontend-app**
-  - [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
+  - [ ] [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
 
 <details>
 <summary>replay command</summary>
@@ -276,12 +276,12 @@ github-code-search "useFeatureFlag" --org fulll
 2 repos · 3 matches selected
 
 - **fulll/auth-service**
-  - [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
+  - [ ] [src/middlewares/featureFlags.ts:2:19](https://github.com/fulll/auth-service/blob/main/src/middlewares/featureFlags.ts#L2)
 - **fulll/billing-api**
-  - [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
-  - [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
+  - [ ] [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
+  - [ ] [src/routes/invoices.ts:1:1](https://github.com/fulll/billing-api/blob/main/src/routes/invoices.ts#L1)
 - **fulll/frontend-app**
-  - [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
+  - [ ] [src/hooks/useFeatureFlag.ts:1:1](https://github.com/fulll/frontend-app/blob/main/src/hooks/useFeatureFlag.ts#L1)
 
 <details>
 <summary>replay command</summary>
@@ -352,22 +352,22 @@ applies the following grouping algorithm:
 ## squad-backend
 
 - **fulll/billing-api** (3 matches)
-  - [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
+  - [ ] [src/flags.ts:3:14](https://github.com/fulll/billing-api/blob/main/src/flags.ts#L3)
 
 ## squad-frontend
 
 - **fulll/auth-service** (2 matches)
-  - [src/middlewares/featureFlags.ts:2:19](...)
+  - [ ] [src/middlewares/featureFlags.ts:2:19](...)
 
 ## squad-frontend + squad-mobile
 
 - **fulll/frontend-app** (1 match)
-  - [src/hooks/useFeatureFlag.ts:1:1](...)
+  - [ ] [src/hooks/useFeatureFlag.ts:1:1](...)
 
 ## other
 
 - **fulll/legacy-monolith** (1 match)
-  - [src/legacy.js:5:1](...)
+  - [ ] [src/legacy.js:5:1](...)
 ```
 
 ### TUI with sections

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -204,8 +204,20 @@ describe("buildMarkdownOutput", () => {
   it("renders each file as an indented sub-bullet", () => {
     const groups = [makeGroup("myorg/repoA", ["src/a.ts", "src/b.ts"])];
     const out = buildMarkdownOutput(groups, QUERY, ORG, new Set(), new Set());
-    expect(out).toContain("  - [src/a.ts](https://github.com/myorg/repoA/blob/main/src/a.ts)");
-    expect(out).toContain("  - [src/b.ts](https://github.com/myorg/repoA/blob/main/src/b.ts)");
+    expect(out).toContain("  - [ ] [src/a.ts](https://github.com/myorg/repoA/blob/main/src/a.ts)");
+    expect(out).toContain("  - [ ] [src/b.ts](https://github.com/myorg/repoA/blob/main/src/b.ts)");
+  });
+
+  it("renders file links as markdown TODO list items (- [ ] [...])", () => {
+    const groups = [makeGroup("myorg/repoA", ["src/foo.ts"])];
+    const out = buildMarkdownOutput(groups, QUERY, ORG, new Set(), new Set());
+    expect(out).toContain("  - [ ] [src/foo.ts](");
+  });
+
+  it("renders file links with location as markdown TODO items", () => {
+    const groups = [makeGroupWithMatches("myorg/repoA", [{ path: "src/foo.ts", line: 3, col: 5 }])];
+    const out = buildMarkdownOutput(groups, QUERY, ORG, new Set(), new Set());
+    expect(out).toContain("  - [ ] [src/foo.ts:3:5](");
   });
 
   it("omits deselected repos", () => {

--- a/src/output.ts
+++ b/src/output.ts
@@ -146,9 +146,9 @@ export function buildMarkdownOutput(
       // absolute line numbers).
       const seg = m.textMatches[0]?.matches[0];
       if (seg) {
-        lines.push(`  - [${m.path}:${seg.line}:${seg.col}](${m.htmlUrl}#L${seg.line})`);
+        lines.push(`  - [ ] [${m.path}:${seg.line}:${seg.col}](${m.htmlUrl}#L${seg.line})`);
       } else {
-        lines.push(`  - [${m.path}](${m.htmlUrl})`);
+        lines.push(`  - [ ] [${m.path}](${m.htmlUrl})`);
       }
     }
   }


### PR DESCRIPTION
## Motivation

Closes #12.

When `--format` is markdown (default), each file extract link was rendered as a plain bullet:

```
- [path:line:col](url#Lline)
```

The issue requests that output be formatted as a proper markdown TODO list instead:

```
- [ ] [path:line:col](url#Lline)
```

This makes the output directly pasteable as a task list into GitHub issues, PR descriptions, or any markdown document.

## What changed

- **`src/output.ts`** — `buildMarkdownOutput`: both the `path:line:col` variant and the plain `path` fallback now emit `- [ ] ` instead of `- `.
- **`src/output.test.ts`** — updated existing assertion on indented sub-bullets; added two new test cases:
  - `renders file links as markdown TODO list items (- [ ] [...])`
  - `renders file links with location as markdown TODO items`
- **`README.md`** — all four example output blocks updated to reflect the new format.

## How to test manually

```bash
bun github-code-search.ts "<query>" --org <org> --no-interactive
```

Each file entry should now start with `  - [ ] `.

## Checklist

- [x] `bun test` — 283 tests pass
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — no diff
- [x] `bun run knip` — no unused exports