### PR TITLE
Fix replay command not including --format, --output-type, --include-archived, --group-by-team-prefix

### DIFF
--- a/github-code-search.ts
+++ b/github-code-search.ts
@@ -155,7 +155,10 @@ async function searchAction(
 
   if (isCI) {
     console.log(
-      buildOutput(groups, query, org, excludedRepos, excludedExtractRefs, format, outputType),
+      buildOutput(groups, query, org, excludedRepos, excludedExtractRefs, format, outputType, {
+        includeArchived,
+        groupByTeamPrefix: opts.groupByTeamPrefix,
+      }),
     );
   } else {
     await runInteractive(
@@ -166,6 +169,8 @@ async function searchAction(
       excludedExtractRefs,
       format,
       outputType,
+      includeArchived,
+      opts.groupByTeamPrefix,
     );
   }
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -31,6 +31,8 @@ export async function runInteractive(
   excludedExtractRefs: Set<string>,
   format: OutputFormat,
   outputType: OutputType = "repo-and-matches",
+  includeArchived = false,
+  groupByTeamPrefix = "",
 ): Promise<void> {
   if (groups.length === 0) {
     console.log(pc.yellow("No results found."));
@@ -123,7 +125,10 @@ export async function runInteractive(
       process.stdout.write(ANSI_CLEAR);
       process.stdin.setRawMode(false);
       console.log(
-        buildOutput(groups, query, org, excludedRepos, excludedExtractRefs, format, outputType),
+        buildOutput(groups, query, org, excludedRepos, excludedExtractRefs, format, outputType, {
+          includeArchived,
+          groupByTeamPrefix,
+        }),
       );
       process.exit(0);
     }


### PR DESCRIPTION
## Root cause

`buildReplayCommand` had no knowledge of `--format`, `--output-type`, `--include-archived`, or `--group-by-team-prefix` — they were never threaded down the call chain from the CLI entry point.

## Steps to reproduce (before the fix)

1. Run `github-code-search query "..." --org myorg --format json --include-archived --group-by-team-prefix squad-`
2. Confirm/exit the TUI — the printed replay command is missing `--format json`, `--include-archived`, and `--group-by-team-prefix squad-`
3. Re-running the replay command produces different output (wrong format, missing archived repos, no team grouping)

## Changes

- `src/output.ts` — Added exported `ReplayOptions` interface (`{ format?, outputType?, includeArchived?, groupByTeamPrefix? }`). Updated `buildReplayCommand` to accept it and emit the missing flags (only when they differ from their defaults). Threaded `ReplayOptions` through `buildReplayDetails`, `buildMarkdownOutput`, `buildJsonOutput`, and `buildOutput`.
- `src/tui.ts` — Added `includeArchived` and `groupByTeamPrefix` params to `runInteractive`; forwards them to `buildOutput`.
- `github-code-search.ts` — Passes `includeArchived` and `opts.groupByTeamPrefix` to both the CI `buildOutput` call and the interactive `runInteractive` call.
- `src/output.test.ts` — Added 12 new tests covering each missing flag in `buildReplayCommand` and `buildOutput`.

## Steps to verify (after the fix)

```bash
bun test               # 295 tests pass
bun run lint           # 0 errors
bun run format:check   # no diff
bun run knip           # no unused exports
bun run build.ts       # binary compiles
```

Fixes #11