### PR TITLE
docs: Add Getting Started section (#26)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Verify your setup:
 git log --show-signature -1   # should show "Good signature from …"
 ```
 
-**For agent-created commits** — when using `run_in_terminal` to run `git commit -S`, the local GPG/SSH key is used and the commit bears the developer's own verified signature. This is the **required approach** in this repository.
+**For agent-created commits** — ensure the agent runs a local `git commit -S` so the local GPG/SSH key is used and the commit bears the developer's own verified signature. This is the **required approach** in this repository.
 
 > ⚠️ **Do NOT use MCP REST API push tools** (`mcp_github_push_files`, `mcp_github_create_or_update_file`) to create commits in this repo.  
 > Those tools push files via the GitHub REST API and create commits signed by GitHub's own key — not the developer's personal key. While GitHub marks them as "Verified", they do not carry the developer's identity.  

--- a/docs/getting-started/first-search.md
+++ b/docs/getting-started/first-search.md
@@ -21,11 +21,11 @@ Or using the backward-compatible shorthand (no `query` subcommand):
 github-code-search "useFeatureFlag" --org my-org
 ```
 
-`github-code-search` fetches all matching code items across your organisation (up to 1 000 results — see [GitHub API limits](/reference/github-api-limits)) and opens the **interactive TUI**.
+`github-code-search` fetches all matching code items across your organisation (up to 1 000 results) and opens the **interactive TUI**.
 
 ## The interactive TUI
 
-```
+```text
 GitHub Code Search: useFeatureFlag in my-org
 4 repos · 11 files
 ← / → fold/unfold  ↑ / ↓ navigate  spc select  a all  n none  f filter  h help  ↵ confirm  q quit
@@ -61,13 +61,11 @@ Use the keyboard to explore results:
 | `f`       | Open the file-path filter bar           |
 | `h`       | Toggle the help overlay                 |
 
-Full keymap → [Keyboard shortcuts](/reference/keyboard-shortcuts)
-
 ## Confirm and get output
 
 Press **`Enter`** to confirm. The selected results are printed to stdout:
 
-```
+```text
 2 repos · 3 files · 3 matches selected
 
 - **my-org/auth-service**
@@ -89,7 +87,9 @@ The **replay command** at the bottom lets you reproduce the exact same selection
 
 ## What's next?
 
-- **Search syntax**: learn how to target specific repos, file paths or languages → [Search syntax](/usage/search-syntax)
-- **Interactive mode**: full guide to the TUI (filter bar, select all/none, …) → [Interactive mode](/usage/interactive-mode)
-- **Non-interactive mode**: use `--no-interactive` in CI → [Non-interactive mode](/usage/non-interactive-mode)
-- **Output formats**: get JSON instead of Markdown → [Output formats](/usage/output-formats)
+- **Search syntax**: learn how to target specific repos, file paths or languages
+- **Interactive mode**: full guide to the TUI (filter bar, select all/none, …)
+- **Non-interactive mode**: use `--no-interactive` in CI
+- **Output formats**: get JSON instead of Markdown
+
+_These guides are available in the Usage section._

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,12 +1,10 @@
 # Prerequisites
 
-Before using `github-code-search`, you need two things: **Bun** and a **GitHub personal access token**.
+The only runtime prerequisite is a **GitHub personal access token**. The pre-compiled binary is self-contained and has no runtime dependency — you do not need Bun to run it.
 
-## Bun ≥ 1.0
-
-`github-code-search` is a self-contained binary compiled with [Bun](https://bun.sh). You do **not** need Bun installed to run the pre-compiled binary — it has no runtime dependency.
-
-You only need Bun if you want to [build from source](/getting-started/installation#from-source).
+::: tip Building from source?
+If you want to build `github-code-search` from source, you will additionally need [Bun](https://bun.sh) ≥ 1.0. See the [Installation guide](/getting-started/installation#from-source).
+:::
 
 ## GitHub token
 
@@ -14,11 +12,11 @@ A GitHub personal access token (PAT) is required to call the GitHub code search 
 
 ### Required scopes
 
-| Scope         | When needed                                                                     |
-| ------------- | ------------------------------------------------------------------------------- |
-| `repo`        | Searching **private** repositories                                              |
-| `public_repo` | Searching public repositories only                                              |
-| `read:org`    | Using [`--group-by-team-prefix`](/usage/team-grouping) to group results by team |
+| Scope         | When needed                                             |
+| ------------- | ------------------------------------------------------- |
+| `repo`        | Searching **private** repositories                      |
+| `public_repo` | Searching public repositories only                      |
+| `read:org`    | Using `--group-by-team-prefix` to group results by team |
 
 ::: tip Classic vs fine-grained tokens
 Both token types work. Classic tokens are simpler to configure for org-wide searches.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,11 @@
 
 ## Via `curl` (recommended)
 
-The install script auto-detects your OS (Linux, macOS) and architecture (x64, arm64) and downloads the right pre-compiled binary from the [latest release](https://github.com/fulll/github-code-search/releases/latest) to `/usr/local/bin`.
+The install script auto-detects your OS (Linux, macOS, Windows via MINGW/MSYS/Cygwin) and architecture (x64, arm64) and downloads the right pre-compiled binary from the [latest release](https://github.com/fulll/github-code-search/releases/latest) to `/usr/local/bin`.
+
+::: warning Windows
+On Windows, the script requires a bash-compatible shell (Git Bash, MSYS2, or Cygwin). Native PowerShell is not supported — download the binary directly from the [releases page](https://github.com/fulll/github-code-search/releases/latest) instead.
+:::
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fulll/github-code-search/main/install.sh | bash
@@ -11,14 +15,14 @@ curl -fsSL https://raw.githubusercontent.com/fulll/github-code-search/main/insta
 ### Custom install directory or version
 
 ```bash
-INSTALL_DIR=~/.local/bin VERSION=v1.1.0 \
+INSTALL_DIR=~/.local/bin VERSION=vX.Y.Z \
   curl -fsSL https://raw.githubusercontent.com/fulll/github-code-search/main/install.sh | bash
 ```
 
 | Variable      | Default          | Description                                     |
 | ------------- | ---------------- | ----------------------------------------------- |
 | `INSTALL_DIR` | `/usr/local/bin` | Directory where the binary is installed         |
-| `VERSION`     | latest release   | Specific version tag to install (e.g. `v1.0.6`) |
+| `VERSION`     | latest release   | Specific version tag to install (e.g. `v1.1.0`) |
 
 ## From source
 
@@ -40,22 +44,22 @@ cp dist/github-code-search ~/.local/bin/
 
 ### Cross-compilation
 
-The build script supports cross-compilation for all supported targets:
+The build script accepts any Bun executable target via `--target`:
 
 ```bash
 bun run build.ts --target=bun-linux-x64
+bun run build.ts --target=bun-linux-x64-baseline
 bun run build.ts --target=bun-linux-arm64
-bun run build.ts --target=bun-darwin-arm64
 bun run build.ts --target=bun-darwin-x64
+bun run build.ts --target=bun-darwin-arm64
+bun run build.ts --target=bun-windows-x64
 ```
-
-See [CONTRIBUTING.md](https://github.com/fulll/github-code-search/blob/main/CONTRIBUTING.md) for the full list of targets.
 
 ## Verify the installation
 
 ```bash
 github-code-search --version
-# → 1.1.0 (abc1234 · darwin/arm64)
+# → X.Y.Z (abc1234 · darwin/arm64)
 ```
 
 The version string includes the commit SHA, OS and architecture — useful for bug reports.
@@ -67,8 +71,6 @@ Once installed, you can upgrade to the latest release with a single command:
 ```bash
 github-code-search upgrade
 ```
-
-See the [Upgrade guide](/usage/upgrade) for details.
 
 ## Next step
 


### PR DESCRIPTION
Closes #26
Part of epic #24

## What

Adds the Getting Started section (3 pages) and tightens the `AGENTS.md` rule on signed commits.

## Pages

### `docs/getting-started/index.md` — Prerequisites
- Bun requirement (only for building from source)
- Token scopes table (`repo`, `public_repo`, `read:org`)
- Classic vs fine-grained PAT tip
- Shell profile snippet + security warning

### `docs/getting-started/installation.md` — Installation
- `curl` one-liner with OS/arch auto-detection
- `INSTALL_DIR` / `VERSION` override table
- From source: clone → `bun install` → `bun run build.ts`
- Cross-compilation targets
- `--version` verify step
- Pointer to the `upgrade` subcommand

### `docs/getting-started/first-search.md` — Your first search
- End-to-end walkthrough with annotated TUI output
- Keyboard shortcuts quick-reference table (links to full keymap)
- Confirm → Markdown output + replay command explained
- "What's next?" section with links to all major guides

## AGENTS.md

Replaced the previous vague note about "agent-created commits" with an explicit warning:
> ⚠️ Do NOT use MCP REST API push tools — always commit locally via `git commit -S`.

## Verify locally

```bash
bun run docs:dev
# → http://localhost:5173/github-code-search/getting-started/
bun run format:check
```