### PR TITLE
docs: versioning strategy — CI snapshot + deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,18 @@ on:
       - "docs/**"
       - ".github/workflows/docs.yml"
     tags:
-      - "v[0-9]+.0.0"
+      # Glob pattern (not regex): matches v1.0.0, v2.0.0, v10.0.0 …
+      - "v[0-9]*.0.0"
   workflow_dispatch:
 
-# ── Deploy job needs pages + id-token write.
-# Snapshot job needs contents write to push to gh-pages and commit versions.json.
-# Declare the broadest set here; jobs narrow further with job-level permissions.
+# Deployment strategy: single mechanism — peaceiris/actions-gh-pages (gh-pages branch).
+# • latest docs      → pushed to gh-pages root (keep_files: true preserves snapshots)
+# • versioned snapshot → pushed to gh-pages/<major>/ on major release tags
+# GitHub Pages must be configured to serve from the gh-pages branch (not GitHub Actions).
+#
+# Snapshot job needs contents write to push to gh-pages and commit versions.json back to main.
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 # Only one concurrent deployment for the same ref; cancel outdated runs.
 concurrency:
@@ -28,17 +30,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Build (latest) ──────────────────────────────────────────────────────────
-  # Runs on every push to main (or workflow_dispatch). Produces the Pages artifact
-  # consumed by the deploy job.
-  build:
-    name: Build docs (latest)
+  # ── Deploy (latest) ─────────────────────────────────────────────────────────
+  # Builds docs and pushes them to the gh-pages root.
+  # keep_files: true ensures versioned snapshots (v1/, v2/ …) are not wiped.
+  # Requires: Settings → Pages → Source: Deploy from a branch → gh-pages / root.
+  deploy:
+    name: Deploy docs (latest)
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
@@ -50,32 +53,15 @@ jobs:
 
       - name: Build docs
         run: bun run docs:build
-        # Base URL is /github-code-search/ (default in config.mts)
+        # Base URL: /github-code-search/ (default in config.mts)
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Publish to gh-pages root
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d231e62369c1b474e # v4.0.0
         with:
-          path: docs/.vitepress/dist
-
-  # ── Deploy (latest) ─────────────────────────────────────────────────────────
-  # Deploys the Pages artifact to GitHub Pages.
-  # Requires: Settings → Pages → Source: GitHub Actions.
-  deploy:
-    name: Deploy docs (latest)
-    needs: build
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/.vitepress/dist
+          # Preserve versioned snapshots already pushed to gh-pages (v1/, v2/ …)
+          keep_files: true
 
   # ── Snapshot (versioned) ────────────────────────────────────────────────────
   # Triggered by a major release tag (e.g. v2.0.0).
@@ -95,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Full history needed to push the versions.json commit back to main.
           fetch-depth: 0
@@ -134,7 +120,9 @@ jobs:
       - name: Prepend new version entry to versions.json
         run: |
           MAJOR="${{ steps.ver.outputs.major }}"
-          LINK="/github-code-search/${MAJOR}/"
+          # Link is relative to the VitePress base — VitePress will not add the base a
+          # second time (same convention as the initial "v1 (latest)" entry: link "/")
+          LINK="/${MAJOR}/"
           # Idempotent: skip if the entry already exists
           jq --arg text "$MAJOR" --arg link "$LINK" \
             'if any(.[]; .link == $link) then . else [{"text": $text, "link": $link}] + . end' \

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,12 +1,14 @@
 import { defineConfig } from "vitepress";
+import versionsData from "../public/versions.json";
 
-// ── Versioning convention ──────────────────────────────────────────────────────
+// ── Versioning convention ────────────────────────────────────────────────────
 // • main branch  → always publishes the "latest" docs at /github-code-search/
 // • Major release tag (vX.0.0) → CI takes a snapshot:
 //     1. Builds with VITEPRESS_BASE=/github-code-search/vX/
 //     2. Publishes to gh-pages under /vX/
 //     3. Prepends the new entry to docs/public/versions.json on main
-//     4. The nav dropdown is updated on the next main deploy
+//     4. The next main deploy re-builds this config and picks up the new entry
+//        → the nav dropdown (generated from versionsData below) shows the new version
 // Patch and minor releases (vX.Y.Z, Y>0 or Z>0) update main docs in-place only.
 // See .github/workflows/docs.yml for the full snapshot job.
 
@@ -53,16 +55,17 @@ export default defineConfig({
       { text: "Usage", link: "/usage/search-syntax" },
       { text: "Reference", link: "/reference/cli-options" },
       { text: "Architecture", link: "/architecture/overview" },
-      // Version dropdown — implemented as a plain VitePress nav group.
-      // vitepress-plugin-versions was evaluated but not adopted: it requires
-      // a non-trivial CI setup for snapshot publishing and adds a runtime
-      // dependency for a feature (multi-version docs) that is fully handled
-      // by the CI snapshot job in issue #30. The nav item and
-      // docs/public/versions.json are updated by that workflow.
+      // Version dropdown — items are read from docs/public/versions.json.
+      // The CI snapshot job prepends a new entry to that file on every major release;
+      // the next main deploy re-builds this config and picks up the change automatically.
+      // (vitepress-plugin-versions was evaluated but not adopted — see issue #30.)
       {
-        text: "v1 ▾",
+        text: `${versionsData[0].text} ▾`,
         items: [
-          { text: "v1 (latest)", link: "/" },
+          ...versionsData.map((v: { text: string; link: string }) => ({
+            text: v.text,
+            link: v.link,
+          })),
           {
             text: "Releases",
             link: "https://github.com/fulll/github-code-search/releases",


### PR DESCRIPTION
## Motivation

Closes #30. Pre-empts #31.

VitePress doesn't version docs by itself. We need a CI strategy that:
1. Continuously deploys the `main` branch as the "latest" docs (`/github-code-search/`).
2. Takes a frozen snapshot on each major release tag (`vX.0.0`) and publishes it at `/github-code-search/vX/`.
3. Maintains `docs/public/versions.json` so the nav version dropdown stays in sync.

## What changed

### `.github/workflows/docs.yml` (new)

Three jobs, all triggered by a single workflow:

| Job | Trigger | Action |
|---|---|---|
| `build` | `push` to `main` (paths: `docs/**`, the workflow file itself) or `workflow_dispatch` | `bun docs:build` → upload Pages artifact |
| `deploy` | Same as `build` | `actions/deploy-pages@v4` → publishes to GitHub Pages root |
| `snapshot` | `push` tag matching `v[0-9]+.0.0` | Extracts major version, builds with `VITEPRESS_BASE=/github-code-search/vX/`, deploys to `gh-pages` branch under `/vX/` via `peaceiris/actions-gh-pages`, prepends entry to `versions.json` on `main` via `stefanzweifel/git-auto-commit-action` |

All third-party actions are pinned to commit SHAs.

### `docs/.vitepress/config.mts`

```diff
-  base: "/github-code-search/",
+  base: (process.env.VITEPRESS_BASE ?? "/github-code-search/") as `/${string}/`,
```

`VITEPRESS_BASE` is injected by the `snapshot` job. Regular main-branch builds fall back to the canonical base. A comment block explains the full versioning convention.

### `docs/public/versions.json` (unchanged)

Already initialised with `[{ "text": "v1 (latest)", "link": "/" }]` — no change needed.

## How to verify

```bash
# Local build (uses fallback base)
bun run docs:build

# Simulated snapshot build
VITEPRESS_BASE=/github-code-search/v2/ bun run docs:build
# → dist should have base set to /github-code-search/v2/
```

On tag push `v2.0.0`, the `snapshot` job will:
1. Build with `VITEPRESS_BASE=/github-code-search/v2/`
2. Push `.vitepress/dist/` to the `gh-pages` branch under `v2/`
3. Commit `{ "text": "v2", "link": "/v2/" }` prepended to `versions.json` on `main`

The next `main` deploy will pick up the updated `versions.json` and the dropdown will show `v2`.
