### PR TITLE
docs: epic #24 polish — SVG icons, animated terminal hero, nav activeMatch, fancy styling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "bun-types": "^1.3.9",
         "knip": "^5.84.1",
         "mermaid": "^11.0.0",
-        "oxfmt": "^0.33.0",
+        "oxfmt": "^0.35.0",
         "oxlint": "^1.48.0",
         "vitepress": "^1.6.3",
         "vitepress-mermaid-renderer": "^1.1.11",
@@ -193,81 +193,81 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.17.1", "", { "os": "win32", "cpu": "x64" }, "sha512-jRPVU+6/12baj87q2+UGRh30FBVBzqKdJ7rP/mSqiL1kpNQB9yZ1j0+m3sru1m+C8hiFK7lBFwjUtYUBI7+UpQ=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.33.0", "", { "os": "android", "cpu": "arm" }, "sha512-ML6qRW8/HiBANteqfyFAR1Zu0VrJu+6o4gkPLsssq74hQ7wDMkufBYJXI16PGSERxEYNwKxO5fesCuMssgTv9w=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.35.0", "", { "os": "android", "cpu": "arm" }, "sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-WimmcyrGpTOntj7F7CO9RMssncOKYall93nBnzJbI2ZZDhVRuCkvFwTpwz80cZqwYm5udXRXfF40ZXcCxjp9jg=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.35.0", "", { "os": "android", "cpu": "arm64" }, "sha512-/O+EbuAJYs6nde/anv+aID6uHsGQApyE9JtYBo/79KyU8e6RBN3DMbT0ix97y1SOnCglurmL2iZ+hlohjP2PnQ=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PorspsX9O5ISstVaq34OK4esN0LVcuU4DVg+XuSqJsfJ//gn6z6WH2Tt7s0rTQaqEcp76g7+QdWQOmnJDZsEVg=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.35.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pGqRtqlNdn9d4VrmGUWVyQjkw79ryhI6je9y2jfqNUIZCfqceob+R97YYAoG7C5TFyt8ILdLVoN+L2vw/hSFyA=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8278bqQtOcHRPhhzcqwN9KIideut+cftBjF8d2TOsSQrlsJSFx41wCCJ38mFmH9NOmU1M+x9jpeobHnbRP1okw=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.35.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8GmsDcSozTPjrCJeGpp+sCmS9+9V5yRrdEZ1p/sTWxPG5nYeAfSLuS0nuEYjXSO+CtdSbStIW6dxa+4NM58yRw=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BiqYVwWFHLf5dkfg0aCKsXa9rpi//vH1+xePCpd7Ulz9yp9pJKP4DWgS5g+OW8MaqOtt7iyAszhxtk/j1nDKHQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.35.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QyfKfTe0ytHpFKHAcHCGQEzN45QSqq1AHJOYYxQMgLM3KY4xu8OsXHpCnINjDsV4XGnQzczJDU9e04Zmd8XqIQ=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-oAVmmurXx0OKbNOVv71oK92LsF1LwYWpnhDnX0VaAy/NLsCKf4B7Zo7lxkJh80nfhU20TibcdwYfoHVaqlStPQ=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.35.0", "", { "os": "linux", "cpu": "arm" }, "sha512-u+kv3JD6P3J38oOyUaiCqgY5TNESzBRZJ5lyZQ6c2czUW2v5SIN9E/KWWa9vxoc+P8AFXQFUVrdzGy1tK+nbPQ=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-YB6S8CiRol59oRxnuclJiWoV6l+l8ru/NsuQNYjXZnnPXfSTXKtMLWHCnL/figpCFYA1E7JyjrBbar1qxe2aZg=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.35.0", "", { "os": "linux", "cpu": "arm" }, "sha512-1NiZroCiV57I7Pf8kOH4XGR366kW5zir3VfSMBU2D0V14GpYjiYmPYFAoJboZvp8ACnZKUReWyMkNKSa5ad58A=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-hrYy+FpWoB6N24E9oGRimhVkqlls9yeqcRmQakEPUHoAbij6rYxsHHYIp3+FHRiQZFAOUxWKn/CCQoy/Mv3Dgw=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.35.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-7Q0Xeg7ZnW2nxnZ4R7aF6DEbCFls4skgHZg+I63XitpNvJCbVIU8MFOTZlvZGRsY9+rPgWPQGeUpLHlyx0wvMA=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-O1YIzymGRdWj9cG5iVTjkP7zk9/hSaVN8ZEbqMnWZjLC1phXlv54cUvANGGXndgJp2JS4W9XENn7eo5I4jZueg=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.35.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.33.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2lrkNe+B0w1tCgQTaozfUNQCYMbqKKCGcnTDATmWCZzO77W2sh+3n04r1lk9Q1CK3bI+C3fPwhFPUR2X2BvlyQ=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.35.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.33.0", "", { "os": "linux", "cpu": "none" }, "sha512-8DSG1q0M6097vowHAkEyHnKed75/BWr1IBtgCJfytnWQg+Jn1X4DryhfjqonKZOZiv74oFQl5J8TCbdDuXXdtQ=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.35.0", "", { "os": "linux", "cpu": "none" }, "sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.33.0", "", { "os": "linux", "cpu": "none" }, "sha512-eWaxnpPz7+p0QGUnw7GGviVBDOXabr6Cd0w7S/vnWTqQo9z1VroT7XXFnJEZ3dBwxMB9lphyuuYi/GLTCxqxlg=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.35.0", "", { "os": "linux", "cpu": "none" }, "sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.33.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-+mH8cQTqq+Tu2CdoB2/Wmk9CqotXResi+gPvXpb+AAUt/LiwpicTQqSolMheQKogkDTYHPuUiSN23QYmy7IXNQ=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.35.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-fjyslAYAPE2+B6Ckrs5LuDQ6lB1re5MumPnzefAXsen3JGwiRilra6XdjUmszTNoExJKbewoxxd6bcLSTpkAJQ=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.35.0", "", { "os": "linux", "cpu": "x64" }, "sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ve/jGBlTt35Jl/I0A0SfCQX3wKnadzPDdyOFEwe2ZgHHIT9uhqhAv1PaVXTenSBpauICEWYH8mWy+ittzlVE/A=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.35.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.33.0", "", { "os": "none", "cpu": "arm64" }, "sha512-lsWRgY9e+uPvwXnuDiJkmJ2Zs3XwwaQkaALJ3/SXU9kjZP0Qh8/tGW8Tk/Z6WL32sDxx+aOK5HuU7qFY9dHJhg=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.35.0", "", { "os": "none", "cpu": "arm64" }, "sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-w8AQHyGDRZutxtQ7IURdBEddwFrtHQiG6+yIFpNJ4HiMyYEqeAWzwBQBfwSAxtSNh6Y9qqbbc1OM2mHN6AB3Uw=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.35.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-uD/NGdM65eKNCDGyTGdO8e9n3IHX+wwuorBvEYrPJXhDXL9qz6gzddmXH8EN04ejUXUujlq4FsoSeCfbg0Y+Jg=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.33.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-j2X4iumKVwDzQtUx3JBDkaydx6eLuncgUZPl2ybZ8llxJMFbZIniws70FzUQePMfMtzLozIm7vo4bjkvQFsOzw=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.35.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-oSRD2k8J2uxYDEKR2nAE/YTY9PobOEnhZgCmspHu0+yBQ665yH8lFErQVSTE7fcGJmJp/cC6322/gc8VFuQf7g=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-lsBQxbepASwOBUh3chcKAjU+jVAQhLElbPYiagIq26cU8vA9Bttj6t20bMvCQCw31m440IRlNhrK7NpnUI8mzA=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.35.0", "", { "os": "win32", "cpu": "x64" }, "sha512-WCDJjlS95NboR0ugI2BEwzt1tYvRDorDRM9Lvctls1SLyKYuNRCyrPwp1urUPFBnwgBNn9p2/gnmo7gFMySRoQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.48.0", "", { "os": "android", "cpu": "arm" }, "sha512-1Pz/stJvveO9ZO7ll4ZoEY3f6j2FiUgBLBcCRCiW6ylId9L9UKs+gn3X28m3eTnoiFCkhKwmJJ+VO6vwsu7Qtg=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.50.0", "", { "os": "android", "cpu": "arm" }, "sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.48.0", "", { "os": "android", "cpu": "arm64" }, "sha512-Zc42RWGE8huo6Ht0lXKjd0NH2lWNmimQHUmD0JFcvShLOuwN+RSEE/kRakc2/0LIgOUuU/R7PaDMCOdQlPgNUQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.50.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GeSuMoJWCVpovJi/e3xDSNgjeR8WEZ6MCXL6EtPiCIM2NTzv7LbflARINTXTJy2oFBYyvdf/l2PwHzYo6EdXvg=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.48.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jgZs563/4vaG5jH2RSt2TSh8A2jwsFdmhLXrElMdm3Mmto0HPf85FgInLSNi9HcwzQFvkYV8JofcoUg2GH1HTA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.50.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w3SY5YtxGnxCHPJ8Twl3KmS9oja1gERYk3AMoZ7Hv8P43ZtB6HVfs02TxvarxfL214Tm3uzvc2vn+DhtUNeKnw=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.48.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-kvo87BujEUjCJREuWDC4aPh1WoXCRFFWE4C7uF6wuoMw2f6N2hypA/cHHcYn9DdL8R2RrgUZPefC8JExyeIMKA=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.50.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hNfogDqy7tvmllXKBSlHo6k5x7dhTUVOHbMSE15CCAcXzmqf5883aPvBYPOq9AE7DpDUQUZ1kVE22YbiGW+tuw=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.48.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-eyzzPaHQKn0RIM+ueDfgfJF2RU//Wp4oaKs2JVoVYcM5HjbCL36+O0S3wO5Xe1NWpcZIG3cEHc/SuOCDRqZDSg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.50.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ykZevOWEyu0nsxolA911ucxpEv0ahw8jfEeGWOwwb/VPoE4xoexuTOAiPNlWZNJqANlJl7yp8OyzCtXTUAxotw=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-p3kSloztK7GRO7FyO3u38UCjZxQTl92VaLDsMQAq0eGoiNmeeEF1KPeE4+Fr+LSkQhF8WvJKSuls6TwOlurdPA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hif3iDk7vo5GGJ4OLCCZAf2vjnU9FztGw4L0MbQL0M2iY9LKFtDMMiQAHmkF0PQGQMVbTYtPdXCLKVgdkiqWXQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.48.0", "", { "os": "linux", "cpu": "arm" }, "sha512-uWM+wiTqLW/V0ZmY/eyTWs8ykhIkzU+K2tz/8m35YepYEzohiUGRbnkpAFXj2ioXpQL+GUe5vmM3SLH6ozlfFw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dVp9iSssiGAnTNey2Ruf6xUaQhdnvcFOJyRWd/mu5o2jVbFK15E5fbWGeFRfmuobu5QXuROtFga44+7DOS3PLg=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OhQNPjs/OICaYqxYJjKKMaIY7p3nJ9IirXcFoHKD+CQE1BZFCeUUAknMzUeLclDCfudH9Vb/UgjFm8+ZM5puAg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1cT7yz2HA910CKA9NkH1ZJo50vTtmND2fkoW1oyiSb0j6WvNtJ0Wx2zoySfXWc/c+7HFoqRK5AbEoL41LOn9oA=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.48.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-adu5txuwGvQ4C4fjYHJD+vnY+OCwCixBzn7J3KF3iWlVHBBImcosSv+Ye+fbMMJui4HGjifNXzonjKm9pXmOiw=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.48.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-inlQQRUnHCny/7b7wA6NjEoJSSZPNea4qnDhWyeqBYWx8ukf2kzNDSiamfhOw6bfAYPm/PVlkVRYaNXQbkLeTQ=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.50.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-YiJx6sW6bYebQDZRVWLKm/Drswx/hcjIgbLIhULSn0rRcBKc7d9V6mkqPjKDbhcxJgQD5Zi0yVccJiOdF40AWA=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.48.0", "", { "os": "linux", "cpu": "none" }, "sha512-zwSqxMgmb2ITamNfDv9Q9EKBc/4ZhCBP9gkg2hhcgR6sEVGPUDl1AKPC89CBKMxkmPUi3685C38EvqtZn5OtHw=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.48.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-c/+2oUWAOsQB5JTem0rW8ODlZllF6pAtGSGXoLSvPTonKI1vAwaKhD9Qw1X36jRbcI3Etkpu/9z/RRjMba8vFQ=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.50.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-PhauDqeFW5DGed6QxCY5lXZYKSlcBdCXJnH03ZNU6QmDZ0BFM/zSy1oPT2MNb1Afx1G6yOOVk8ErjWsQ7c59ng=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.48.0", "", { "os": "linux", "cpu": "x64" }, "sha512-6d7LIFFZGiavbHndhf1cK9kG9qmy2Dmr37sV9Ep7j3H+ciFdKSuOzdLh85mEUYMih+b+esMDlF5DU0WQRZPQjw=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.48.0", "", { "os": "none", "cpu": "arm64" }, "sha512-r+0KK9lK6vFp3tXAgDMOW32o12dxvKS3B9La1uYMGdWAMoSeu2RzG34KmzSpXu6MyLDl4aSVyZLFM8KGdEjwaw=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.50.0", "", { "os": "none", "cpu": "arm64" }, "sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.48.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Nkw/MocyT3HSp0OJsKPXrcbxZqSPMTYnLLfsqsoiFKoL1ppVNL65MFa7vuTxJehPlBkjy+95gUgacZtuNMECrg=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.50.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fq0M6vsGcFsSfeuWAACDhd5KJrO85ckbEfe1EGuBj+KPyJz7KeWte2fSFrFGmNKNXyhEMyx4tbgxiWRujBM2KQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.48.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-reO1SpefvRmeZSP+WeyWkQd1ArxxDD1MyKgMUKuB8lNuUoxk9QEohYtKnsfsxJuFwMT0JTr7p9wZjouA85GzGQ=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.50.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-qTdWR9KwY/vxJGhHVIZG2eBOhidOQvOwzDxnX+jhW/zIVacal1nAhR8GLkiywW8BIFDkQKXo/zOfT+/DY+ns/w=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.48.0", "", { "os": "win32", "cpu": "x64" }, "sha512-T6zwhfcsrorqAybkOglZdPkTLlEwipbtdO1qjE+flbawvwOMsISoyiuaa7vM7zEyfq1hmDvMq1ndvkYFioranA=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.50.0", "", { "os": "win32", "cpu": "x64" }, "sha512-682t7npLC4G2Ca+iNlI9fhAKTcFPYYXJjwoa88H4q+u5HHHlsnL/gHULapX3iqp+A8FIJbgdylL5KMYo2LaluQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
@@ -627,7 +627,7 @@
 
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
 
-    "knip": ["knip@5.84.1", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "js-yaml": "^4.1.1", "minimist": "^1.2.8", "oxc-resolver": "^11.15.0", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-F1+yACEsSapAwmQLzfD4i9uPsnI82P4p5ABpNQ9pcc4fpQtjHEX34XDtNl5863I4O6SCECpymylcWDHI3ouhQQ=="],
+    "knip": ["knip@5.85.0", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "jiti": "^2.6.0", "js-yaml": "^4.1.1", "minimist": "^1.2.8", "oxc-resolver": "^11.15.0", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "zod": "^4.1.11" }, "peerDependencies": { "@types/node": ">=18", "typescript": ">=5.0.4 <7" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-V2kyON+DZiYdNNdY6GALseiNCwX7dYdpz9Pv85AUn69Gk0UKCts+glOKWfe5KmaMByRjM9q17Mzj/KinTVOyxg=="],
 
     "langium": ["langium@4.2.1", "", { "dependencies": { "chevrotain": "~11.1.1", "chevrotain-allstar": "~0.3.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ=="],
 
@@ -673,9 +673,9 @@
 
     "oxc-resolver": ["oxc-resolver@11.17.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.17.1", "@oxc-resolver/binding-android-arm64": "11.17.1", "@oxc-resolver/binding-darwin-arm64": "11.17.1", "@oxc-resolver/binding-darwin-x64": "11.17.1", "@oxc-resolver/binding-freebsd-x64": "11.17.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.17.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.17.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.17.1", "@oxc-resolver/binding-linux-arm64-musl": "11.17.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.17.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.17.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.17.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.17.1", "@oxc-resolver/binding-linux-x64-gnu": "11.17.1", "@oxc-resolver/binding-linux-x64-musl": "11.17.1", "@oxc-resolver/binding-openharmony-arm64": "11.17.1", "@oxc-resolver/binding-wasm32-wasi": "11.17.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.17.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.17.1", "@oxc-resolver/binding-win32-x64-msvc": "11.17.1" } }, "sha512-pyRXK9kH81zKlirHufkFhOFBZRks8iAMLwPH8gU7lvKFiuzUH9L8MxDEllazwOb8fjXMcWjY1PMDfMJ2/yh5cw=="],
 
-    "oxfmt": ["oxfmt@0.33.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.33.0", "@oxfmt/binding-android-arm64": "0.33.0", "@oxfmt/binding-darwin-arm64": "0.33.0", "@oxfmt/binding-darwin-x64": "0.33.0", "@oxfmt/binding-freebsd-x64": "0.33.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.33.0", "@oxfmt/binding-linux-arm-musleabihf": "0.33.0", "@oxfmt/binding-linux-arm64-gnu": "0.33.0", "@oxfmt/binding-linux-arm64-musl": "0.33.0", "@oxfmt/binding-linux-ppc64-gnu": "0.33.0", "@oxfmt/binding-linux-riscv64-gnu": "0.33.0", "@oxfmt/binding-linux-riscv64-musl": "0.33.0", "@oxfmt/binding-linux-s390x-gnu": "0.33.0", "@oxfmt/binding-linux-x64-gnu": "0.33.0", "@oxfmt/binding-linux-x64-musl": "0.33.0", "@oxfmt/binding-openharmony-arm64": "0.33.0", "@oxfmt/binding-win32-arm64-msvc": "0.33.0", "@oxfmt/binding-win32-ia32-msvc": "0.33.0", "@oxfmt/binding-win32-x64-msvc": "0.33.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-ogxBXA9R4BFeo8F1HeMIIxHr5kGnQwKTYZ5k131AEGOq1zLxInNhvYSpyRQ+xIXVMYfCN7yZHKff/lb5lp4auQ=="],
+    "oxfmt": ["oxfmt@0.35.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.35.0", "@oxfmt/binding-android-arm64": "0.35.0", "@oxfmt/binding-darwin-arm64": "0.35.0", "@oxfmt/binding-darwin-x64": "0.35.0", "@oxfmt/binding-freebsd-x64": "0.35.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.35.0", "@oxfmt/binding-linux-arm-musleabihf": "0.35.0", "@oxfmt/binding-linux-arm64-gnu": "0.35.0", "@oxfmt/binding-linux-arm64-musl": "0.35.0", "@oxfmt/binding-linux-ppc64-gnu": "0.35.0", "@oxfmt/binding-linux-riscv64-gnu": "0.35.0", "@oxfmt/binding-linux-riscv64-musl": "0.35.0", "@oxfmt/binding-linux-s390x-gnu": "0.35.0", "@oxfmt/binding-linux-x64-gnu": "0.35.0", "@oxfmt/binding-linux-x64-musl": "0.35.0", "@oxfmt/binding-openharmony-arm64": "0.35.0", "@oxfmt/binding-win32-arm64-msvc": "0.35.0", "@oxfmt/binding-win32-ia32-msvc": "0.35.0", "@oxfmt/binding-win32-x64-msvc": "0.35.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-QYeXWkP+aLt7utt5SLivNIk09glWx9QE235ODjgcEZ3sd1VMaUBSpLymh6ZRCA76gD2rMP4bXanUz/fx+nLM9Q=="],
 
-    "oxlint": ["oxlint@1.48.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.48.0", "@oxlint/binding-android-arm64": "1.48.0", "@oxlint/binding-darwin-arm64": "1.48.0", "@oxlint/binding-darwin-x64": "1.48.0", "@oxlint/binding-freebsd-x64": "1.48.0", "@oxlint/binding-linux-arm-gnueabihf": "1.48.0", "@oxlint/binding-linux-arm-musleabihf": "1.48.0", "@oxlint/binding-linux-arm64-gnu": "1.48.0", "@oxlint/binding-linux-arm64-musl": "1.48.0", "@oxlint/binding-linux-ppc64-gnu": "1.48.0", "@oxlint/binding-linux-riscv64-gnu": "1.48.0", "@oxlint/binding-linux-riscv64-musl": "1.48.0", "@oxlint/binding-linux-s390x-gnu": "1.48.0", "@oxlint/binding-linux-x64-gnu": "1.48.0", "@oxlint/binding-linux-x64-musl": "1.48.0", "@oxlint/binding-openharmony-arm64": "1.48.0", "@oxlint/binding-win32-arm64-msvc": "1.48.0", "@oxlint/binding-win32-ia32-msvc": "1.48.0", "@oxlint/binding-win32-x64-msvc": "1.48.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.12.2" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-m5vyVBgPtPhVCJc3xI//8je9lRc8bYuYB4R/1PH3VPGOjA4vjVhkHtyJukdEjYEjwrw4Qf1eIf+pP9xvfhfMow=="],
+    "oxlint": ["oxlint@1.50.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.50.0", "@oxlint/binding-android-arm64": "1.50.0", "@oxlint/binding-darwin-arm64": "1.50.0", "@oxlint/binding-darwin-x64": "1.50.0", "@oxlint/binding-freebsd-x64": "1.50.0", "@oxlint/binding-linux-arm-gnueabihf": "1.50.0", "@oxlint/binding-linux-arm-musleabihf": "1.50.0", "@oxlint/binding-linux-arm64-gnu": "1.50.0", "@oxlint/binding-linux-arm64-musl": "1.50.0", "@oxlint/binding-linux-ppc64-gnu": "1.50.0", "@oxlint/binding-linux-riscv64-gnu": "1.50.0", "@oxlint/binding-linux-riscv64-musl": "1.50.0", "@oxlint/binding-linux-s390x-gnu": "1.50.0", "@oxlint/binding-linux-x64-gnu": "1.50.0", "@oxlint/binding-linux-x64-musl": "1.50.0", "@oxlint/binding-openharmony-arm64": "1.50.0", "@oxlint/binding-win32-arm64-msvc": "1.50.0", "@oxlint/binding-win32-ia32-msvc": "1.50.0", "@oxlint/binding-win32-x64-msvc": "1.50.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.14.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ=="],
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,10 +51,22 @@ export default defineConfig({
   themeConfig: {
     // ── Nav ──────────────────────────────────────────────────────────────────
     nav: [
-      { text: "Getting Started", link: "/getting-started/" },
-      { text: "Usage", link: "/usage/search-syntax" },
-      { text: "Reference", link: "/reference/cli-options" },
-      { text: "Architecture", link: "/architecture/overview" },
+      {
+        text: "Getting Started",
+        link: "/getting-started/",
+        activeMatch: "^/getting-started/",
+      },
+      { text: "Usage", link: "/usage/search-syntax", activeMatch: "^/usage/" },
+      {
+        text: "Reference",
+        link: "/reference/cli-options",
+        activeMatch: "^/reference/",
+      },
+      {
+        text: "Architecture",
+        link: "/architecture/overview",
+        activeMatch: "^/architecture/",
+      },
       // Version dropdown — items are read from docs/public/versions.json.
       // The CI snapshot job prepends a new entry to that file on every major release;
       // the next main deploy re-builds this config and picks up the change automatically.

--- a/docs/.vitepress/theme/TerminalDemo.vue
+++ b/docs/.vitepress/theme/TerminalDemo.vue
@@ -1,0 +1,410 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from "vue";
+
+const visible = ref(false);
+
+const CMD = 'github-code-search query "useState"';
+const typedCmd = ref("");
+const showLoader = ref(false);
+const visibleCount = ref(0);
+const cursorIdx = ref(-1);
+const selected = ref<Set<number>>(new Set());
+const showReplay = ref(false);
+const bodyScroll = ref(0);
+const scrollInstant = ref(false);
+
+interface Line {
+  type: "repo" | "file" | "code" | "gap";
+  text: string;
+  count?: string;
+}
+
+const LINES: Line[] = [
+  { type: "repo", text: "▸ acme/frontend", count: "3 matches" },
+  { type: "file", text: "src/hooks/useUser.ts" },
+  { type: "code", text: "const [user] = useState(null)" },
+  { type: "file", text: "src/pages/App.tsx" },
+  { type: "code", text: "useState(initialState)" },
+  { type: "gap", text: "" },
+  { type: "repo", text: "▸ acme/dashboard", count: "2 matches" },
+  { type: "file", text: "src/components/Modal.tsx" },
+  { type: "code", text: "const [open] = useState(false)" },
+];
+
+// Indices of navigable code lines in LINES
+const CODE_IDXS = [2, 4, 8];
+
+let timers: ReturnType<typeof setTimeout>[] = [];
+let active = true;
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => {
+    if (!active) return resolve();
+    timers.push(setTimeout(resolve, ms));
+  });
+}
+
+async function run() {
+  for (;;) {
+    // reset state — instant (no transition)
+    scrollInstant.value = true;
+    bodyScroll.value = 0;
+    typedCmd.value = "";
+    showLoader.value = false;
+    visibleCount.value = 0;
+    cursorIdx.value = -1;
+    selected.value = new Set();
+    showReplay.value = false;
+    // re-enable transition after a tick
+    await wait(16);
+    scrollInstant.value = false;
+
+    await wait(500);
+    if (!active) break;
+
+    // type the command char by char
+    for (let i = 1; i <= CMD.length; i++) {
+      typedCmd.value = CMD.slice(0, i);
+      await wait(38);
+      if (!active) break;
+    }
+
+    await wait(300);
+
+    // show loader briefly
+    showLoader.value = true;
+    await wait(700);
+    showLoader.value = false;
+
+    // reveal result lines one by one
+    for (let i = 0; i < LINES.length; i++) {
+      visibleCount.value = i + 1;
+      // start scrolling after line 6 to keep content in view
+      if (i >= 5) bodyScroll.value = (i - 5) * 20;
+      await wait(70);
+      if (!active) break;
+    }
+
+    await wait(500);
+    // scroll a touch more so hints are fully visible
+    bodyScroll.value = 28;
+
+    // navigate cursor through code lines
+    for (const idx of CODE_IDXS) {
+      cursorIdx.value = idx;
+      await wait(500);
+      if (!active) break;
+    }
+
+    // select first and last code lines
+    selected.value = new Set([CODE_IDXS[0], CODE_IDXS[2]]);
+    await wait(700);
+
+    // show replay command
+    showReplay.value = true;
+    bodyScroll.value = 70;
+    await wait(2400);
+    if (!active) break;
+  }
+}
+
+onMounted(() => {
+  visible.value = true;
+  run();
+});
+
+onUnmounted(() => {
+  active = false;
+  timers.forEach(clearTimeout);
+  timers = [];
+});
+</script>
+
+<template>
+  <div class="td" :class="{ visible }">
+    <!-- chrome bar -->
+    <div class="td-chrome">
+      <span class="td-dot td-red" />
+      <span class="td-dot td-yellow" />
+      <span class="td-dot td-green" />
+      <span class="td-title">github-code-search</span>
+    </div>
+
+    <!-- terminal body -->
+    <div class="td-body">
+      <div
+        class="td-body-inner"
+        :class="{ 'td-instant': scrollInstant }"
+        :style="{ transform: `translateY(-${bodyScroll}px)` }"
+      >
+        <!-- prompt line -->
+        <div class="td-prompt">
+          <span class="td-ps">$</span>
+          <span class="td-cmd">{{ typedCmd }}</span>
+          <span class="td-cursor" />
+        </div>
+
+        <!-- searching... -->
+        <div v-if="showLoader" class="td-loader">Searching<span class="td-dots">...</span></div>
+
+        <!-- result lines -->
+        <template v-for="(line, i) in LINES" :key="i">
+          <div
+            v-if="i < visibleCount"
+            class="td-line"
+            :class="{
+              'td-repo': line.type === 'repo',
+              'td-file': line.type === 'file',
+              'td-code': line.type === 'code',
+              'td-gap': line.type === 'gap',
+              'td-active': cursorIdx === i,
+              'td-sel': selected.has(i),
+            }"
+          >
+            <template v-if="line.type === 'repo'">
+              <span>{{ line.text }}</span>
+              <span class="td-count">{{ line.count }}</span>
+            </template>
+            <template v-else-if="line.type === 'code'">
+              <span class="td-mark">{{ selected.has(i) ? "✓" : cursorIdx === i ? "›" : " " }}</span>
+              <span>{{ line.text }}</span>
+            </template>
+            <template v-else>
+              <span>{{ line.text }}</span>
+            </template>
+          </div>
+        </template>
+
+        <!-- replay command -->
+        <template v-if="showReplay">
+          <div class="td-replay-label">↩ replay</div>
+          <div class="td-line td-replay-cmd">
+            <span class="td-ps">$</span>
+            <span>query "useState" --exclude acme/dashboard</span>
+          </div>
+        </template>
+
+        <!-- keyboard hints -->
+        <div v-if="visibleCount >= LINES.length" class="td-hints">
+          <span>↑↓ nav</span><span>·</span><span>space sel</span><span>·</span
+          ><span>↵ confirm</span>
+        </div>
+      </div>
+      <!-- /td-body-inner -->
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ── Container ───────────────────────────────────────────────────────── */
+.td {
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+  font-size: 11.5px;
+  line-height: 1.55;
+  width: 460px;
+  max-width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px rgba(153, 51, 255, 0.22),
+    0 24px 64px rgba(0, 0, 0, 0.5),
+    0 0 48px rgba(153, 51, 255, 0.12);
+  /* skeleton: invisible until mounted */
+  opacity: 0;
+  transform: translateY(14px) scale(0.97);
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
+}
+
+.td.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+/* ── Chrome bar ──────────────────────────────────────────────────────── */
+.td-chrome {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  background: #1e1c2e;
+  border-bottom: 1px solid rgba(153, 51, 255, 0.15);
+}
+
+.td-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.td-red {
+  background: #ff5f57;
+}
+.td-yellow {
+  background: #febc2e;
+}
+.td-green {
+  background: #28c840;
+}
+
+.td-title {
+  flex: 1;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+}
+
+/* ── Body ────────────────────────────────────────────────────────────── */
+.td-body {
+  background: #0f0d1a;
+  padding: 12px 14px 10px;
+  height: 240px;
+  overflow: hidden;
+}
+
+.td-body-inner {
+  transition: transform 0.35s ease;
+}
+
+.td-body-inner.td-instant {
+  transition: none;
+}
+
+/* ── Prompt ──────────────────────────────────────────────────────────── */
+.td-prompt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  color: #e8e8f0;
+}
+
+.td-ps {
+  color: #9933ff;
+  font-weight: 700;
+}
+
+.td-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 13px;
+  background: #9933ff;
+  vertical-align: middle;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/* ── Loader ──────────────────────────────────────────────────────────── */
+.td-loader {
+  color: #88889a;
+  padding: 2px 0 6px;
+}
+
+.td-dots {
+  animation: dotsblink 1.2s steps(4, end) infinite;
+}
+
+@keyframes dotsblink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.25;
+  }
+}
+
+/* ── Result lines ────────────────────────────────────────────────────── */
+.td-line {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 1px 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.td-repo {
+  color: #9933ff;
+  font-weight: 600;
+  margin-top: 5px;
+  justify-content: space-between;
+}
+
+.td-count {
+  color: rgba(153, 51, 255, 0.5);
+  font-size: 10px;
+  font-weight: 400;
+}
+
+.td-file {
+  color: #555568;
+  padding-left: 10px;
+}
+
+.td-code {
+  color: #c8c8d8;
+  padding-left: 2px;
+}
+
+.td-gap {
+  height: 3px;
+}
+
+/* active cursor row */
+.td-code.td-active {
+  background: rgba(153, 51, 255, 0.15);
+  border-left: 2px solid #9933ff;
+  padding-left: 0;
+  border-radius: 2px;
+}
+
+/* selected row */
+.td-code.td-sel {
+  color: rgba(190, 255, 210, 0.85);
+}
+
+.td-code.td-sel .td-mark {
+  color: #4ade80;
+}
+
+.td-mark {
+  width: 12px;
+  flex-shrink: 0;
+  display: inline-block;
+  color: rgba(153, 51, 255, 0.65);
+}
+
+/* ── Replay ──────────────────────────────────────────────────────────── */
+.td-replay-label {
+  color: rgba(153, 51, 255, 0.55);
+  font-size: 10.5px;
+  margin-top: 7px;
+  padding: 0 2px;
+}
+
+.td-replay-cmd {
+  color: #d4d4d4;
+  gap: 6px;
+}
+
+/* ── Keyboard hints ──────────────────────────────────────────────────── */
+.td-hints {
+  display: flex;
+  gap: 5px;
+  margin-top: 8px;
+  padding-top: 7px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.22);
+  font-size: 10px;
+}
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -40,6 +40,269 @@
   --vp-c-brand-soft: rgba(204, 136, 255, 0.16);
 }
 
-span.name.clip {
+/* ── Hero title gradient ─────────────────────────────────────────────────── */
+/* VitePress reads these two variables to apply a gradient clip to .name.clip  */
+:root {
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(135deg, #9933ff 0%, #cc88ff 55%, #ffcc33 100%);
+}
+
+.VPHero span.name.clip {
   min-width: 100%;
+}
+
+/* ── Top accent bar ──────────────────────────────────────────────────────── */
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #9933ff 0%, #cc88ff 40%, #ffcc33 70%, #ff9933 100%);
+  z-index: 9999;
+  pointer-events: none;
+}
+
+/* ── Home page background glow ───────────────────────────────────────────── */
+.VPHome {
+  background: radial-gradient(
+    ellipse 90% 45% at 50% -5%,
+    rgba(153, 51, 255, 0.09) 0%,
+    transparent 100%
+  );
+}
+
+.dark .VPHome {
+  background: radial-gradient(
+    ellipse 90% 45% at 50% -5%,
+    rgba(153, 51, 255, 0.16) 0%,
+    transparent 100%
+  );
+}
+
+/* ── Hero terminal demo image ────────────────────────────────────────────── */
+.VPHero .image {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* Cancel VitePress's decorative translate(-32px,-32px) that causes overlap  */
+.VPHero .image-container {
+  max-width: unset !important;
+  width: auto !important;
+  height: auto !important;
+  transform: none !important;
+}
+
+/* Hide the decorative radial bg blob (designed for icon images, not terminal) */
+.VPHero .image-bg {
+  display: none !important;
+}
+
+/* Below 1280px: hide the image column — mobile slot takes over             */
+@media (max-width: 1279px) {
+  .VPHero .image {
+    display: none !important;
+  }
+
+  .VPHero span.text {
+    min-width: 100%;
+  }
+
+  .VPHero p.tagline {
+    min-width: 100%;
+  }
+}
+
+/* ≥1280px: constrain image column to prevent it eating into the text       */
+@media (min-width: 1280px) {
+  /* Gap between the text column and the terminal */
+  .VPHero.has-image .container {
+    gap: 64px;
+  }
+
+  .VPHero.has-image .image {
+    flex: 0 0 450px !important;
+    max-width: 450px !important;
+  }
+
+  .td-slot-desktop .td {
+    width: 450px;
+  }
+}
+
+/* 960-1279px: image hidden but container is still flex-row — force column  */
+@media (min-width: 960px) and (max-width: 1279px) {
+  .VPHero.has-image .container {
+    flex-direction: column !important;
+    align-items: center !important;
+  }
+
+  .VPHero.has-image .main {
+    max-width: 720px !important;
+    text-align: center !important;
+  }
+
+  .VPHero.has-image .actions {
+    justify-content: center !important;
+  }
+}
+
+/* Slot shown on desktop only (home-hero-image, ≥1280px) */
+.td-slot-desktop {
+  display: none;
+}
+
+/* Slot shown on mobile/tablet only (home-hero-info-after, <1280px) */
+.td-slot-mobile {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 28px;
+  margin-bottom: 28px;
+}
+
+/* On desktop (≥1280px): swap which slot is visible */
+@media (min-width: 1280px) {
+  .td-slot-desktop {
+    display: block;
+  }
+
+  .td-slot-mobile {
+    display: none;
+  }
+}
+
+/* On mobile: constrain terminal width so it doesn't overflow */
+@media (max-width: 640px) {
+  .td-slot-mobile .td {
+    width: 100%;
+    font-size: 10.5px;
+  }
+}
+
+/* ── Feature cards ───────────────────────────────────────────────────────── */
+.VPFeature {
+  border-color: rgba(153, 51, 255, 0.14) !important;
+  background: linear-gradient(
+    155deg,
+    var(--vp-c-bg-soft) 0%,
+    rgba(153, 51, 255, 0.04) 100%
+  ) !important;
+  transition:
+    border-color 0.25s,
+    box-shadow 0.25s,
+    transform 0.25s !important;
+}
+
+.VPFeature:hover {
+  border-color: rgba(153, 51, 255, 0.38) !important;
+  box-shadow: 0 8px 32px rgba(153, 51, 255, 0.13) !important;
+  transform: translateY(-3px);
+}
+
+.dark .VPFeature {
+  border-color: rgba(204, 136, 255, 0.12) !important;
+  background: linear-gradient(
+    155deg,
+    var(--vp-c-bg-soft) 0%,
+    rgba(153, 51, 255, 0.07) 100%
+  ) !important;
+}
+
+.dark .VPFeature:hover {
+  border-color: rgba(204, 136, 255, 0.32) !important;
+  box-shadow: 0 8px 36px rgba(153, 51, 255, 0.22) !important;
+}
+
+/* Icon: no background, use brand colour, scale up slightly */
+.VPFeature .icon {
+  background-color: transparent !important;
+  color: var(--vp-c-brand-1);
+  font-size: 32px;
+}
+
+.VPFeature .icon svg {
+  width: 36px;
+  height: 36px;
+}
+
+/* ── Hero buttons ────────────────────────────────────────────────────────── */
+.VPHero .VPButton.brand {
+  background: linear-gradient(135deg, #9933ff 0%, #7a1fd4 100%);
+  border-color: transparent;
+  box-shadow: 0 2px 16px rgba(153, 51, 255, 0.4);
+  transition:
+    box-shadow 0.2s,
+    transform 0.18s;
+}
+
+.VPHero .VPButton.brand:hover {
+  background: linear-gradient(135deg, #aa44ff 0%, #9933ff 100%);
+  box-shadow: 0 6px 28px rgba(153, 51, 255, 0.55);
+  transform: translateY(-2px);
+}
+
+.VPHero .VPButton.alt {
+  border-color: rgba(153, 51, 255, 0.35);
+  transition:
+    border-color 0.2s,
+    background 0.2s;
+}
+
+.VPHero .VPButton.alt:hover {
+  border-color: rgba(153, 51, 255, 0.6);
+  background: rgba(153, 51, 255, 0.08);
+}
+
+.dark .VPHero .VPButton.alt {
+  border-color: rgba(204, 136, 255, 0.35);
+}
+
+.dark .VPHero .VPButton.alt:hover {
+  border-color: rgba(204, 136, 255, 0.6);
+  background: rgba(153, 51, 255, 0.12);
+}
+
+/* ── Navigation bar ──────────────────────────────────────────────────────── */
+.VPNavBar {
+  border-bottom: 1px solid rgba(153, 51, 255, 0.12) !important;
+}
+
+.dark .VPNavBar {
+  border-bottom-color: rgba(204, 136, 255, 0.1) !important;
+}
+
+/* ── Doc pages background (non-home) ──────────────────────────────────────── */
+.VPDoc {
+  background: radial-gradient(
+    ellipse 80% 30% at 50% 0%,
+    rgba(153, 51, 255, 0.05) 0%,
+    transparent 100%
+  );
+}
+
+.dark .VPDoc {
+  background: radial-gradient(
+    ellipse 80% 30% at 50% 0%,
+    rgba(153, 51, 255, 0.09) 0%,
+    transparent 100%
+  );
+}
+
+/* ── Footer (black — fulll.fr style) ─────────────────────────────────────── */
+.VPFooter {
+  border-top: none !important;
+  background: #111 !important;
+}
+
+.VPFooter .message,
+.VPFooter .copyright {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+.dark .VPFooter {
+  background: #0f0f0f !important;
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import { useData } from "vitepress";
 import { createMermaidRenderer } from "vitepress-mermaid-renderer";
+import TerminalDemo from "./TerminalDemo.vue";
 import "./custom.css";
 
 export default {
@@ -27,6 +28,11 @@ export default {
       () => initMermaid(),
     );
 
-    return h(DefaultTheme.Layout);
+    return h(DefaultTheme.Layout, null, {
+      // Desktop (≥1280px): image slot → right side of hero
+      "home-hero-image": () => h("div", { class: "td-slot-desktop" }, [h(TerminalDemo)]),
+      // Mobile/tablet (<1280px): after tagline, before action buttons
+      "home-hero-info-after": () => h("div", { class: "td-slot-mobile" }, [h(TerminalDemo)]),
+    });
   },
 } satisfies Theme;

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,22 +14,28 @@ hero:
       link: https://github.com/fulll/github-code-search
 
 features:
-  - icon: 🔍
+  - icon:
+      src: /icons/search.svg
     title: Org-wide code search
     details: Search across all repositories in a GitHub organisation in a single command. Results are paginated automatically — up to 1,000 items.
-  - icon: 📦
+  - icon:
+      src: /icons/layers.svg
     title: Per-repository aggregation
     details: Results are grouped by repository, not shown as a flat list. Fold or unfold each repo to focus on what matters.
-  - icon: ⌨️
+  - icon:
+      src: /icons/terminal.svg
     title: Keyboard-driven TUI
     details: Navigate with arrow keys, select individual extracts, filter by file path, and confirm with Enter — all without leaving the terminal.
-  - icon: 🎯
+  - icon:
+      src: /icons/target.svg
     title: Fine-grained selection
     details: Pick exactly the repos and code extracts you want. Deselected items are recorded as exclusions in the replay command.
-  - icon: 📄
+  - icon:
+      src: /icons/file-code.svg
     title: Structured output
     details: Get clean Markdown lists with GitHub links, or machine-readable JSON — ready to paste into docs, issues or scripts.
-  - icon: 🔁
+  - icon:
+      src: /icons/replay.svg
     title: Replay command
     details: Every interactive session produces a one-liner you can run in CI to reproduce the exact same selection without the UI.
 ---

--- a/docs/public/icons/file-code.svg
+++ b/docs/public/icons/file-code.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/>
+  <path d="M14 2v6h6"/>
+  <path d="m9 13 2 2-2 2"/>
+  <line x1="13" y1="15" x2="16" y2="15"/>
+</svg>

--- a/docs/public/icons/layers.svg
+++ b/docs/public/icons/layers.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m2 7 10-4 10 4-10 4Z"/>
+  <path d="m2 12 10 4 10-4"/>
+  <path d="m2 17 10 4 10-4"/>
+</svg>

--- a/docs/public/icons/replay.svg
+++ b/docs/public/icons/replay.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+  <path d="M3 3v5h5"/>
+</svg>

--- a/docs/public/icons/search.svg
+++ b/docs/public/icons/search.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="11" cy="11" r="8"/>
+  <path d="m21 21-4.35-4.35"/>
+  <polyline points="8.5 9.5 11 11.5 8.5 13.5"/>
+  <line x1="12.5" y1="11.5" x2="14.5" y2="11.5"/>
+</svg>

--- a/docs/public/icons/target.svg
+++ b/docs/public/icons/target.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <circle cx="12" cy="12" r="6"/>
+  <circle cx="12" cy="12" r="2"/>
+</svg>

--- a/docs/public/icons/terminal.svg
+++ b/docs/public/icons/terminal.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9933FF" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="3" width="20" height="18" rx="2"/>
+  <path d="m7 9 3 3-3 3"/>
+  <line x1="13" y1="15" x2="17" y2="15"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bun-types": "^1.3.9",
     "knip": "^5.84.1",
     "mermaid": "^11.0.0",
-    "oxfmt": "^0.33.0",
+    "oxfmt": "^0.35.0",
     "oxlint": "^1.48.0",
     "vitepress": "^1.6.3",
     "vitepress-mermaid-renderer": "^1.1.11"


### PR DESCRIPTION
Closes #24

## What's in this PR

Final polish for the VitePress documentation site.

### SVG feature card icons
- 6 SVG files in `docs/public/icons/` (violet `#9933FF` stroke) replacing the broken inline-YAML `svg:` approach
- Referenced via `icon: { src: /icons/name.svg }` in `index.md` frontmatter — VitePress applies `withBase()` automatically

### Animated terminal hero
- New `TerminalDemo.vue` component injected via the `home-hero-image` slot (desktop ≥1280px) and `home-hero-info-after` slot (tablet/mobile)
- Animates a full loop: typing → searching → results appearing line by line → cursor navigation → selection → replay command
- Fixed height body with smooth internal scroll, skeleton fade-in on mount, full cleanup on unmount

### Navigation `activeMatch`
- All nav items now highlight correctly on sub-pages (`/usage/*`, `/reference/*`, `/architecture/*`, `/getting-started/*`)

### Fulll-brand styling (`custom.css`)
- Top accent bar (violet → yellow gradient)
- Hero title gradient clip
- Feature card hover effects + violet border
- Hero buttons (gradient brand, outlined alt)
- `.VPNavBar` border (correct selector)
- `.VPDoc` subtle radial glow on doc pages
- Black footer (`#111`) — fulll.fr style

### Responsive layout
- Desktop ≥1280px: 2-column hero, terminal right-aligned in a `400px` fixed column, `gap: 48px` between text and terminal, `transform: none` cancels VitePress's decorative offset, `.image-bg` hidden
- 960–1279px: column forced to `flex-direction: column` + centered (same as mobile)
- Mobile: terminal centred between tagline and buttons, full-width on small screens