### PR TITLE
Fix upgrade bootstrap: legacy darwin/win32 asset aliases + selectAsset fallback

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -83,6 +83,14 @@ jobs:
           path: dist/
           merge-multiple: true
 
+      - name: Create legacy artifact aliases (backward-compat for upgrade)
+        # Fix: binaries built before v1.2.1 look for darwin-* / win32-* asset names.
+        # Publishing these aliases lets old binaries upgrade themselves — see issue #45.
+        run: |
+          cp dist/github-code-search-macos-arm64 dist/github-code-search-darwin-arm64
+          cp dist/github-code-search-macos-x64 dist/github-code-search-darwin-x64
+          cp dist/github-code-search-windows-x64.exe dist/github-code-search-win32-x64.exe
+
       - name: Create release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:

--- a/src/upgrade.test.ts
+++ b/src/upgrade.test.ts
@@ -93,6 +93,40 @@ describe("selectAsset", () => {
   it("returns null for empty asset list", () => {
     expect(selectAsset([], "darwin", "arm64")).toBeNull();
   });
+
+  describe("legacy fallback (pre-v1.2.1 asset names)", () => {
+    const legacyAssets: ReleaseAsset[] = [
+      makeAsset("github-code-search-darwin-arm64"),
+      makeAsset("github-code-search-darwin-x64"),
+      makeAsset("github-code-search-linux-x64"),
+      makeAsset("github-code-search-linux-arm64"),
+      makeAsset("github-code-search-win32-x64.exe"),
+    ];
+
+    it("falls back to darwin-arm64 when macos-arm64 is absent", () => {
+      const asset = selectAsset(legacyAssets, "darwin", "arm64");
+      expect(asset?.name).toBe("github-code-search-darwin-arm64");
+    });
+
+    it("falls back to darwin-x64 when macos-x64 is absent", () => {
+      const asset = selectAsset(legacyAssets, "darwin", "x64");
+      expect(asset?.name).toBe("github-code-search-darwin-x64");
+    });
+
+    it("falls back to win32-x64.exe when windows-x64.exe is absent", () => {
+      const asset = selectAsset(legacyAssets, "win32", "x64");
+      expect(asset?.name).toBe("github-code-search-win32-x64.exe");
+    });
+
+    it("prefers canonical macos-arm64 over legacy darwin-arm64 when both present", () => {
+      const mixed = [
+        makeAsset("github-code-search-darwin-arm64"),
+        makeAsset("github-code-search-macos-arm64"),
+      ];
+      const asset = selectAsset(mixed, "darwin", "arm64");
+      expect(asset?.name).toBe("github-code-search-macos-arm64");
+    });
+  });
 });
 
 // ─── fetchLatestRelease ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

The fix in #46 (v1.2.1) corrected `selectAsset` to look for `macos-arm64` instead of `darwin-arm64`. However, binaries already installed (≤ v1.1.0) still contain the **old** code and will forever look for `github-code-search-darwin-arm64` in every future release — creating a permanent bootstrap failure.

```
error: No binary found for platform darwin/arm64 in release v1.2.1.
```

## Changes

### `src/upgrade.ts` — fallback to legacy asset names

`selectAsset` now tries the canonical name first (`macos-arm64`), then falls back to the raw Node.js platform name (`darwin-arm64`) so that old binaries can always upgrade:

```typescript
const legacyName = `github-code-search-${platform}-${arch}${legacySuffix}`;
return assets.find((a) => a.name === name) ?? assets.find((a) => a.name === legacyName) ?? null;
```

### `.github/workflows/cd.yaml` — publish legacy aliases in every release

After downloading the canonical artifacts, the release job copies them under the old names:

```bash
cp dist/github-code-search-macos-arm64   dist/github-code-search-darwin-arm64
cp dist/github-code-search-macos-x64     dist/github-code-search-darwin-x64
cp dist/github-code-search-windows-x64.exe dist/github-code-search-win32-x64.exe
```

Both fixes are complementary: the CD change unblocks users on v1.1.0 immediately; the `selectAsset` fallback provides resilience for any future naming drift.

### `src/upgrade.test.ts` — new tests for the fallback

Added a `legacy fallback` describe block covering all three legacy platform names and verifying that the canonical name takes precedence when both are present.

## Steps to reproduce (before the fix)

1. Install `github-code-search` v1.1.0 (any darwin/arm64 machine).
2. Run `github-code-search upgrade`.
3. Observe: `error: No binary found for platform darwin/arm64 in release v1.2.1.`

## Steps to verify (after the fix)

- `bun test` → 347 pass, 0 fail
- `bun run lint` → 0 errors
- `bun run format:check` → no diff
- `bun run knip` → no issues
- Once merged and a new release is cut, both v1.1.0 *and* v1.2.1 binaries will successfully self-upgrade.

Closes #45