### PR TITLE
Fix TUI only displaying first text fragment when a file has multiple matches

### DIFF
--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -297,6 +297,31 @@ describe("rowTerminalLines", () => {
     };
     expect(rowTerminalLines(undefined, row)).toBe(2);
   });
+
+  // Fix: rowTerminalLines must account for all textMatches, not just textMatches[0] — see issue #74
+  it("extract row with two single-line fragments takes 3 lines (1 path + 2 fragments)", () => {
+    const group: RepoGroup = {
+      repoFullName: "org/repo",
+      matches: [
+        {
+          path: "src/foo.ts",
+          repoFullName: "org/repo",
+          htmlUrl: "https://github.com/org/repo/blob/main/src/foo.ts",
+          archived: false,
+          textMatches: [
+            { fragment: "first match line", matches: [] },
+            { fragment: "second match line", matches: [] },
+          ],
+        },
+      ],
+      folded: false,
+      repoSelected: true,
+      extractSelected: [true],
+    };
+    const row: Row = { type: "extract", repoIndex: 0, extractIndex: 0 };
+    // 1 line for the path + 1 line per fragment = 3 total
+    expect(rowTerminalLines(group, row)).toBe(3);
+  });
 });
 
 // ─── buildRows ────────────────────────────────────────────────────────────────
@@ -661,6 +686,35 @@ describe("renderGroups", () => {
     expect(repoLine).toBeDefined();
     const visibleLen = repoLine!.replace(/\x1b\[[0-9;]*m/g, "").length;
     expect(visibleLen).toBe(termWidth);
+  });
+
+  // Fix: renderGroups must display all textMatches for a file, not just textMatches[0] — see issue #74
+  it("shows all fragments when a file has multiple textMatches", () => {
+    const groups: RepoGroup[] = [
+      {
+        repoFullName: "org/repo",
+        matches: [
+          {
+            path: "src/multi.ts",
+            repoFullName: "org/repo",
+            htmlUrl: "https://github.com/org/repo/blob/main/src/multi.ts",
+            archived: false,
+            textMatches: [
+              { fragment: "first_fragment_content", matches: [] },
+              { fragment: "second_fragment_content", matches: [] },
+            ],
+          },
+        ],
+        folded: false,
+        repoSelected: true,
+        extractSelected: [true],
+      },
+    ];
+    const rows = buildRows(groups);
+    const out = renderGroups(groups, 0, rows, 40, 0, "q", "org");
+    const stripped = out.replace(/\x1b\[[0-9;]*m/g, "");
+    expect(stripped).toContain("first_fragment_content");
+    expect(stripped).toContain("second_fragment_content");
   });
 });
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -389,8 +389,8 @@ export function renderGroups(
         : `${highlightText(match.path, "path", pc.cyan)}${pc.dim(locSuffix)}`;
       lines.push(`${INDENT}${INDENT}${checkbox} ${filePath}`);
 
-      if (match.textMatches.length > 0) {
-        const tm = match.textMatches[0];
+      // Fix: render every fragment, not just textMatches[0] — see issue #74
+      for (const tm of match.textMatches) {
         // When filtering by content, overlay the typed pattern on the fragment.
         const extraSegs =
           filterTarget === "content" && activeFilter

--- a/src/render/rows.ts
+++ b/src/render/rows.ts
@@ -10,9 +10,14 @@ export function rowTerminalLines(group: RepoGroup | undefined, row: Row): number
   if (row.type === "repo") return 1;
   const match = group!.matches[row.extractIndex!];
   if (match.textMatches.length === 0) return 1;
-  // 1 line for the file path + N lines for the fragment
-  const rawLines = match.textMatches[0].fragment.split("\n");
-  return 1 + Math.min(rawLines.length, MAX_FRAGMENT_LINES + 1); // +1 for potential "more" line
+  // Fix: sum lines for every fragment, not just textMatches[0] — see issue #74
+  // 1 line for the file path + N lines per fragment
+  let total = 1;
+  for (const tm of match.textMatches) {
+    const rawLines = tm.fragment.split("\n");
+    total += Math.min(rawLines.length, MAX_FRAGMENT_LINES + 1); // +1 for potential "more" line
+  }
+  return total;
 }
 
 /**


### PR DESCRIPTION
## Root cause

When the GitHub Code Search API returns multiple `text_matches` for the same file (i.e. several distinct code fragments in the same file all match the query), the TUI was silently discarding every fragment after the first one.

The bug existed in two places:

1. **`src/render/rows.ts` — `rowTerminalLines`**: the function computed the terminal height of an extract row using only `textMatches[0].fragment`, making the viewport height calculation wrong for multi-fragment files.

2. **`src/render.ts` — `renderGroups`**: the extract rendering block unconditionally read `match.textMatches[0]` and never iterated further, so only the first fragment was pushed to the output lines.

## Changes

| File | Change |
|---|---|
| `src/render/rows.ts` | `rowTerminalLines` now sums `MIN(lines, MAX)` across **all** `textMatches` entries |
| `src/render.ts` | Extract render block now iterates over **all** `textMatches` with a `for…of` loop |
| `src/render.test.ts` | Two new regression tests (written first, failing before the fix — TDD) |

## Steps to reproduce (before the fix)

Run any query where a file contains multiple distinct occurrences of the search pattern, so the GitHub API returns several `text_matches` for that file. Open the TUI — only the first fragment is visible.

## Steps to verify (after the fix)

```bash
bun test               # 408 pass, 0 fail
bun run lint           # 0 warnings / 0 errors
bun run format:check   # no diff
bun run knip           # no unused exports
```

Both new tests (`rowTerminalLines > extract row with two single-line fragments takes 3 lines` and `renderGroups > shows all fragments when a file has multiple textMatches`) pass.

Fixes #74