### PR TITLE
v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Each release entry covers the motivation, new features, breaking changes (if any
 
 | Version                                                                  | Blog post                                                                                                       |
 | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [v1.8.3](https://fulll.github.io/github-code-search/blog/release-v1-8-3) | Fix TUI layout: header/footer anchoring, viewport packing, narrow-terminal clipping, active-row contrast        |
 | [v1.8.2](https://fulll.github.io/github-code-search/blog/release-v1-8-2) | Fix rate-limit errors aborting multi-page searches; auto-wait and retry with live progress                      |
 | [v1.8.1](https://fulll.github.io/github-code-search/blog/release-v1-8-1) | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution                |
 | [v1.8.0](https://fulll.github.io/github-code-search/blog/release-v1-8-0) | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help           |

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -11,6 +11,7 @@ Full release notes and changelogs are always available on
 
 | Release                    | Highlights                                                                                                 |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [v1.8.3](./release-v1-8-3) | Fix TUI layout: header/footer anchoring, viewport packing and narrow-terminal rendering                    |
 | [v1.8.2](./release-v1-8-2) | Fix rate-limit errors aborting multi-page searches — auto-wait and resume with live feedback               |
 | [v1.8.1](./release-v1-8-1) | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution           |
 | [v1.8.0](./release-v1-8-0) | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help      |

--- a/docs/blog/release-v1-8-3.md
+++ b/docs/blog/release-v1-8-3.md
@@ -1,0 +1,55 @@
+---
+title: "What's new in v1.8.3"
+description: "Fix TUI layout: header/footer anchoring, viewport packing and narrow-terminal rendering"
+date: 2026-03-09
+---
+
+# What's new in github-code-search v1.8.3
+
+> Full release notes: <https://github.com/fulll/github-code-search/releases/tag/v1.8.3>
+
+## Highlights
+
+### Fix: header no longer scrolls off screen
+
+In previous versions, scrolling down fast could push the `github-code-search`
+title bar and the column headers (`PATH`, `MATCH`) out of the visible area,
+leaving the TUI without any reference point. The header row is now anchored to
+the top of the viewport regardless of scroll offset.
+
+### Fix: footer always visible at the bottom
+
+The keyboard-shortcut bar at the bottom of the TUI could float up into the
+results area when the result list was shorter than the terminal height.  
+The viewport now fills any remaining vertical space with blank lines before
+rendering the footer, keeping it pinned to the last row.
+
+### Fix: correct rendering on narrow terminals (Unicode / emoji clipping)
+
+The `clipAnsi` helper that truncates long lines to fit the terminal width was
+splitting multi-byte UTF-8 sequences such as emoji (e.g. `🔍`) at a raw byte
+boundary, producing garbled output or invisible characters on narrow terminals.  
+The helper now advances by full Unicode code points (`codePointAt`) and only
+clips between complete characters.
+
+---
+
+## Other improvements
+
+- **Title badge contrast** — the `github-code-search` badge in the header now
+  renders in black on magenta instead of a low-contrast colour combination,
+  making it readable on all common terminal themes.
+- **Viewport packing** — `normalizeScrollOffset` prevents the scroll position
+  from drifting past the last result, ensuring the bottom of the list always
+  fills the screen.
+
+---
+
+## Upgrade
+
+```sh
+github-code-search upgrade
+```
+
+Or download the latest binary from
+[GitHub Releases](https://github.com/fulll/github-code-search/releases/tag/v1.8.3).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-code-search",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Interactive GitHub code search with per-repo aggregation",
   "keywords": [
     "bun",


### PR DESCRIPTION
## v1.8.3 — Fix TUI layout

### Root cause

Three independent bugs in the TUI rendering pipeline:

1. **Header scrolling off screen** — the title/column header row was rendered as part of the scrollable content instead of being anchored before the scroll region.
2. **Footer floating up** — when the result list was shorter than the terminal height, the keyboard-shortcut bar moved up into the results area instead of staying pinned to the last row.
3. **Narrow-terminal clipping corrupting multi-byte characters** — `clipAnsi` advanced byte-by-byte, splitting surrogate pairs / emoji at a raw byte boundary and producing garbled output.

### Changes

- **`src/render.ts`** — header anchored above scroll region; footer preceded by blank-line padding (`for (let i = usedLines; i < viewportHeight; i++) lines.push("")`) to fill the viewport; `clipAnsi` now iterates with `codePointAt` to advance by full Unicode code points and appends `\x1b[22;39m` (partial reset preserving background) instead of a full `\x1b[0m`; `maxPathVisible` and `maxLeftVisible` floors lowered to `Math.max(1, ...)`; section label `maxLabelChars` floor lowered to `Math.max(0, ...)` with blank-line placeholders when 0.
- **`src/render/rows.ts`** — new `normalizeScrollOffset()` pure function that decreases the scroll offset when the current position leaves blank space at the bottom of the viewport.
- **`src/tui.ts`** — `normalizeScrollOffset` called in a fixed-point loop inside `redraw()` so the offset always fills the screen; `getRepoRowIndexMap` lazy O(1) Map replacing O(n) `findIndex`; title badge now renders as `pc.bgMagenta(pc.black(pc.bold(...)))` for maximum contrast.
- **`docs/blog/release-v1-8-3.md`** + `docs/blog/index.md` + `CHANGELOG.md` — release notes.

### Steps to reproduce (before the fix)

```sh
# On a terminal tall enough to show blank space below results:
github-code-search query "foo" --org myorg
# → scroll down: header disappears  
# → on a short result set: footer floats above the last line
# → on a narrow terminal with emoji in paths: garbled characters
```

### Steps to verify (after the fix)

```sh
bun test          # 567 pass, 0 fail
bun run lint      # zero errors
bun run format:check
bun run knip
bun run build.ts
```

Closes #105