### PR TITLE
v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,21 @@ Release notes and changelogs are published on the **[project blog](https://fulll
 
 Each release entry covers the motivation, new features, breaking changes (if any), and upgrade notes.
 
-| Version                                                                  | Blog post                                                                                                       |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| [v1.9.0](https://fulll.github.io/github-code-search/blog/release-v1-9-0) | Windows support — native x64, x64-modern, x64-baseline and ARM64 binaries with one-line PowerShell installer    |
-| [v1.8.3](https://fulll.github.io/github-code-search/blog/release-v1-8-3) | Fix TUI layout: header/footer anchoring, viewport packing, narrow-terminal clipping, active-row contrast        |
-| [v1.8.2](https://fulll.github.io/github-code-search/blog/release-v1-8-2) | Fix rate-limit errors aborting multi-page searches; auto-wait and retry with live progress                      |
-| [v1.8.1](https://fulll.github.io/github-code-search/blog/release-v1-8-1) | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution                |
-| [v1.8.0](https://fulll.github.io/github-code-search/blog/release-v1-8-0) | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help           |
-| [v1.7.0](https://fulll.github.io/github-code-search/blog/release-v1-7-0) | Shell completions (bash/zsh/fish) + extended syntax highlighting (PHP, C/C++, Swift, Terraform/HCL, Dockerfile) |
-| [v1.6.1](https://fulll.github.io/github-code-search/blog/release-v1-6-1) | Fix TUI only displaying first text fragment when a file has multiple matches                                    |
-| [v1.6.0](https://fulll.github.io/github-code-search/blog/release-v1-6-0) | Power navigation: global fold/unfold, gg/G top/bottom, paged scroll, open-in-browser                            |
-| [v1.5.0](https://fulll.github.io/github-code-search/blog/release-v1-5-0) | Advanced filter targets, regex mode, word-jump, scroll fix                                                      |
-| [v1.4.0](https://fulll.github.io/github-code-search/blog/release-v1-4-0) | TUI visual overhaul, community files, demo animation                                                            |
-| [v1.3.0](https://fulll.github.io/github-code-search/blog/release-v1-3-0) | Team-prefix grouping, replay command, JSON output                                                               |
-| [v1.0.0](https://fulll.github.io/github-code-search/blog/release-v1-0-0) | Initial release                                                                                                 |
+| Version                                                                    | Blog post                                                                                                       |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [v1.10.0](https://fulll.github.io/github-code-search/blog/release-v1-10-0) | Native regex syntax `/pattern/flags` — automatic term extraction, top-level alternation and `--regex-hint`      |
+| [v1.9.0](https://fulll.github.io/github-code-search/blog/release-v1-9-0)   | Windows support — native x64, x64-modern, x64-baseline and ARM64 binaries with one-line PowerShell installer    |
+| [v1.8.3](https://fulll.github.io/github-code-search/blog/release-v1-8-3)   | Fix TUI layout: header/footer anchoring, viewport packing, narrow-terminal clipping, active-row contrast        |
+| [v1.8.2](https://fulll.github.io/github-code-search/blog/release-v1-8-2)   | Fix rate-limit errors aborting multi-page searches; auto-wait and retry with live progress                      |
+| [v1.8.1](https://fulll.github.io/github-code-search/blog/release-v1-8-1)   | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution                |
+| [v1.8.0](https://fulll.github.io/github-code-search/blog/release-v1-8-0)   | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help           |
+| [v1.7.0](https://fulll.github.io/github-code-search/blog/release-v1-7-0)   | Shell completions (bash/zsh/fish) + extended syntax highlighting (PHP, C/C++, Swift, Terraform/HCL, Dockerfile) |
+| [v1.6.1](https://fulll.github.io/github-code-search/blog/release-v1-6-1)   | Fix TUI only displaying first text fragment when a file has multiple matches                                    |
+| [v1.6.0](https://fulll.github.io/github-code-search/blog/release-v1-6-0)   | Power navigation: global fold/unfold, gg/G top/bottom, paged scroll, open-in-browser                            |
+| [v1.5.0](https://fulll.github.io/github-code-search/blog/release-v1-5-0)   | Advanced filter targets, regex mode, word-jump, scroll fix                                                      |
+| [v1.4.0](https://fulll.github.io/github-code-search/blog/release-v1-4-0)   | TUI visual overhaul, community files, demo animation                                                            |
+| [v1.3.0](https://fulll.github.io/github-code-search/blog/release-v1-3-0)   | Team-prefix grouping, replay command, JSON output                                                               |
+| [v1.0.0](https://fulll.github.io/github-code-search/blog/release-v1-0-0)   | Initial release                                                                                                 |
 
 > For the full list of commits between releases, see the
 > [GitHub Releases page](https://github.com/fulll/github-code-search/releases).

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -9,20 +9,21 @@ Full release notes and changelogs are always available on
 
 ## v1 series
 
-| Release                    | Highlights                                                                                                 |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| [v1.9.0](./release-v1-9-0) | Windows support — native x64, x64-modern, x64-baseline and ARM64 binaries with one-line PowerShell install |
-| [v1.8.3](./release-v1-8-3) | Fix TUI layout: header/footer anchoring, viewport packing and narrow-terminal rendering                    |
-| [v1.8.2](./release-v1-8-2) | Fix rate-limit errors aborting multi-page searches — auto-wait and resume with live feedback               |
-| [v1.8.1](./release-v1-8-1) | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution           |
-| [v1.8.0](./release-v1-8-0) | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help      |
-| [v1.7.0](./release-v1-7-0) | Shell completions (bash/zsh/fish), extended syntax highlighting (PHP, C/C++, Swift, Terraform, Dockerfile) |
-| [v1.6.1](./release-v1-6-1) | Fix TUI rendering only the first fragment for multi-match files                                            |
-| [v1.6.0](./release-v1-6-0) | Power navigation: global fold/unfold (`Z`), Vim `gg`/`G` jumps, paged scroll, open-in-browser (`o`)        |
-| [v1.5.0](./release-v1-5-0) | Advanced filter targets (content/path/repo), regex mode, word-jump shortcuts, scroll accuracy fix          |
-| [v1.4.0](./release-v1-4-0) | TUI visual overhaul, violet branding, demo animation, SECURITY / Code of Conduct, README improvements      |
-| [v1.3.0](./release-v1-3-0) | Richer upgrade output, update-available notice, colorized `--help`, deep doc links, What's New blog        |
-| [v1.0.0](./release-v1-0-0) | Initial public release — interactive TUI, per-repo aggregation, markdown / JSON output                     |
+| Release                      | Highlights                                                                                                 |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [v1.10.0](./release-v1-10-0) | Native regex syntax `/pattern/flags` — automatic term extraction, top-level alternation and `--regex-hint` |
+| [v1.9.0](./release-v1-9-0)   | Windows support — native x64, x64-modern, x64-baseline and ARM64 binaries with one-line PowerShell install |
+| [v1.8.3](./release-v1-8-3)   | Fix TUI layout: header/footer anchoring, viewport packing and narrow-terminal rendering                    |
+| [v1.8.2](./release-v1-8-2)   | Fix rate-limit errors aborting multi-page searches — auto-wait and resume with live feedback               |
+| [v1.8.1](./release-v1-8-1)   | Fix silent hang after pagination bar — concurrency cap + progress bar for line-number resolution           |
+| [v1.8.0](./release-v1-8-0)   | Purple TUI theme, fetch progress bar, position indicator, line-anchored file links, Esc to close help      |
+| [v1.7.0](./release-v1-7-0)   | Shell completions (bash/zsh/fish), extended syntax highlighting (PHP, C/C++, Swift, Terraform, Dockerfile) |
+| [v1.6.1](./release-v1-6-1)   | Fix TUI rendering only the first fragment for multi-match files                                            |
+| [v1.6.0](./release-v1-6-0)   | Power navigation: global fold/unfold (`Z`), Vim `gg`/`G` jumps, paged scroll, open-in-browser (`o`)        |
+| [v1.5.0](./release-v1-5-0)   | Advanced filter targets (content/path/repo), regex mode, word-jump shortcuts, scroll accuracy fix          |
+| [v1.4.0](./release-v1-4-0)   | TUI visual overhaul, violet branding, demo animation, SECURITY / Code of Conduct, README improvements      |
+| [v1.3.0](./release-v1-3-0)   | Richer upgrade output, update-available notice, colorized `--help`, deep doc links, What's New blog        |
+| [v1.0.0](./release-v1-0-0)   | Initial public release — interactive TUI, per-repo aggregation, markdown / JSON output                     |
 
 ---
 

--- a/docs/blog/release-v1-10-0.md
+++ b/docs/blog/release-v1-10-0.md
@@ -1,0 +1,99 @@
+---
+title: "What's new in v1.10.0"
+description: "Native regex support — search with /pattern/flags syntax, automatic API term extraction, top-level alternation and --regex-hint override."
+date: 2026-03-13
+---
+
+# What's new in github-code-search v1.10.0
+
+> Full release notes: <https://github.com/fulll/github-code-search/releases/tag/v1.10.0>
+
+## Highlights
+
+### Regex query syntax
+
+`github-code-search` now supports **full regex queries** using the `/pattern/flags` notation
+— the same syntax accepted by the GitHub web search UI.
+
+```bash
+# Any import of axios, regardless of quote style
+github-code-search "/from.*['\"\`]axios/" --org my-org
+
+# Axios pinned to any semver-prefix in package.json
+github-code-search '/"axios": "[~^]?[0-9]"/ filename:package.json' --org my-org
+
+# Legacy require() calls for a specific module
+github-code-search "/require\\(['\"](old-lib)['\"]\\)/" --org my-org
+
+# TODO, FIXME or HACK comments in one query
+github-code-search "/TODO|FIXME|HACK/" --org my-org
+```
+
+Because the GitHub Code Search API does not support regex natively, the CLI automatically
+extracts a representative literal term from the pattern to send to the API, then
+**filters the returned results locally** with the full regex. In the vast majority of cases
+this is entirely transparent.
+
+### Automatic API term extraction
+
+The extraction algorithm picks the **longest unambiguous literal sequence** from the regex:
+
+- `/require\(['"]axios['"]\)/` → sends `require` to the API
+- `/"version": "\d+\.\d+/` → sends `"version": "` to the API
+- `/TODO|FIXME|HACK/` → sends `TODO OR FIXME OR HACK` (see below)
+
+If no term of 3+ characters can be extracted, the CLI exits with a clear error and
+instructs you to use `--regex-hint`.
+
+### Top-level alternation — no results missed
+
+When the regex pattern contains a **top-level `|`** (not nested inside `(...)` or `[...]`),
+the CLI automatically builds an `A OR B OR C` GitHub query so that **every branch is covered**
+by the API fetch — not just the first one.
+
+```bash
+# Sends: "TODO OR FIXME OR HACK" to the GitHub API
+github-code-search "/TODO|FIXME|HACK/" --org my-org
+```
+
+### `--regex-hint` — manual API term override
+
+For patterns where the auto-extracted term is too short or too broad, use `--regex-hint`
+to specify exactly what the API should search for, while the **full regex is still applied
+locally** to filter results:
+
+```bash
+github-code-search '/"axios":\s*"[~^]?[0-9]/ filename:package.json' \
+  --org my-org \
+  --regex-hint '"axios"'
+```
+
+`--regex-hint` is also recorded in the **replay command** included in the markdown output,
+so the exact same result set can be reproduced without re-triggering the warning.
+
+### Accurate match highlighting
+
+In regex mode the TUI highlights the **actual regex match positions** inside each code
+fragment — not the approximate positions returned by the GitHub API for the literal search
+term. Match locations in the output (`:line:col` suffixes and `#L` GitHub anchors) reflect
+the true match boundaries.
+
+### Invalid regex is always a hard error
+
+Malformed patterns (e.g. unclosed groups, bad escape sequences) are detected at startup
+and produce a clear fatal error before any API call is made:
+
+```text
+⚠  Regex mode — Invalid regex /foo(/: Unterminated group
+```
+
+---
+
+## Upgrade
+
+```bash
+github-code-search upgrade
+```
+
+Or grab the latest binary directly from the
+[GitHub Releases page](https://github.com/fulll/github-code-search/releases/tag/v1.10.0).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-code-search",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Interactive GitHub code search with per-repo aggregation",
   "keywords": [
     "bun",


### PR DESCRIPTION
## Release v1.10.0 — Native regex support

Bumps `package.json` to `1.10.0` and adds the release blog post + index/changelog updates.

### What's in this release (merged via #114)

- **Regex query syntax** — `/pattern/flags` notation, identical to the GitHub web UI
- **Automatic API term extraction** — longest literal sequence from the regex is sent to the GitHub API; results are filtered locally with the full pattern
- **Top-level alternation** — `/TODO|FIXME|HACK/` sends `TODO OR FIXME OR HACK` so every branch is covered
- **`--regex-hint`** — manual override for the API search term when auto-extraction is too short/broad; recorded in the replay command
- **Accurate match highlighting** — TUI highlights actual regex match positions, not approx. API positions
- **Invalid regex = hard error** — malformed patterns are caught before any API call

### Files changed

| File | Change |
|------|--------|
| `package.json` | `1.9.0` → `1.10.0` |
| `docs/blog/release-v1-10-0.md` | New blog post |
| `docs/blog/index.md` | Added v1.10.0 row |
| `CHANGELOG.md` | Added v1.10.0 row |

### Verification

```bash
bun test          # 664 pass, 0 fail
bun run lint      # 0 errors
bun run format:check  # clean
bun run knip      # no unused exports
```

The `v1.10.0` tag has already been pushed — the CD pipeline (`cd.yaml`) is building all-platform binaries and will create the GitHub Release automatically.