### PR TITLE
Fix missing `matchedText` key in JSON result

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -146,6 +146,28 @@ describe("fetchAllResults", () => {
     expect(results[0].textMatches[0].matches[0].col).toBe(1);
   });
 
+  it("derives segment text from fragment when GitHub omits match text", async () => {
+    const fakeItem = {
+      path: "package.json",
+      html_url: "https://github.com/org/repo/blob/main/package.json",
+      repository: { full_name: "org/repo", archived: false },
+      text_matches: [
+        {
+          fragment: '{"dependencies":{"react-dom":"18.3.1"}}',
+          matches: [{ indices: [18, 27] }],
+        },
+      ],
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ items: [fakeItem], total_count: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    const results = await fetchAllResults("react-dom filename:package.json", "org", "tok");
+    expect(results[0].textMatches[0].matches[0].text).toBe("react-dom");
+  });
+
   it("marks archived repos correctly", async () => {
     const fakeItem = {
       path: "lib/old.ts",

--- a/src/api.ts
+++ b/src/api.ts
@@ -22,6 +22,18 @@ interface RawCodeItem {
   text_matches?: RawTextMatch[];
 }
 
+function deriveSegmentText(
+  fragment: string,
+  indices: [number, number],
+  providedText?: string,
+): string {
+  if (providedText !== undefined) return providedText;
+  const [rawStart, rawEnd] = indices;
+  const start = Math.max(0, Math.min(rawStart, fragment.length));
+  const end = Math.max(start, Math.min(rawEnd, fragment.length));
+  return fragment.slice(start, end);
+}
+
 interface SearchCodeResponse {
   items: RawCodeItem[];
   total_count: number;
@@ -287,7 +299,7 @@ export async function fetchAllResults(
             const indices = seg.indices;
             const { line: fragLine, col } = segmentLineCol(fragment, indices[0]);
             const line = fragmentStartLine + fragLine - 1;
-            return { text: seg.text ?? "", indices, line, col };
+            return { text: deriveSegmentText(fragment, indices, seg.text), indices, line, col };
           }),
         };
       }),

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -622,7 +622,7 @@ describe("buildJsonOutput — line/col fields", () => {
   });
 
   it("omits matchedText when seg.text is an empty string", () => {
-    // api.ts normalizes missing segment text to "" — matchedText must not be emitted
+    // Empty segment text should not emit matchedText in JSON output.
     const groups: RepoGroup[] = [
       {
         repoFullName: "myorg/repoA",


### PR DESCRIPTION
This pull request improves the handling of text matches in search results, specifically addressing cases where GitHub omits the matched text. The main changes ensure that the matched text is accurately derived from the fragment when necessary, and that the output remains consistent.

**Text match derivation and normalization:**

* Added a new function `deriveSegmentText` in `src/api.ts` to extract the matched text from the fragment using indices when GitHub does not provide the text. This function is now used when processing search results. [[1]](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700R25-R36) [[2]](diffhunk://#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700L290-R302)
* Updated the test suite in `src/api.test.ts` to verify that segment text is correctly derived from the fragment when omitted by GitHub.

**Test and comment improvements:**

* Clarified the comment in `src/output.test.ts` to reflect that empty segment text should not emit `matchedText` in the JSON output.