### PR TITLE
Fail fast on unbalanced quotes in plain-text queries

### DIFF
--- a/github-code-search.ts
+++ b/github-code-search.ts
@@ -24,7 +24,7 @@ import { groupByTeamPrefix, flattenTeamSections, applyTeamPick } from "./src/gro
 import { checkForUpdate } from "./src/upgrade.ts";
 import { runInteractive } from "./src/tui.ts";
 import { generateCompletion, detectShell } from "./src/completions.ts";
-import { buildApiQuery, isRegexQuery } from "./src/regex.ts";
+import { buildApiQuery, isRegexQuery, validateQuoteBalance } from "./src/regex.ts";
 import type { OutputFormat, OutputType } from "./src/types.ts";
 
 // Version + build metadata injected at compile time via --define (see build.ts).
@@ -232,6 +232,13 @@ async function searchAction(
   const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
   if (!GITHUB_TOKEN) {
     console.error(pc.red("Error: GITHUB_TOKEN environment variable is not set."));
+    process.exit(1);
+  }
+
+  // Fail fast on unbalanced quotes rather than surfacing a raw GitHub 422 — see issue #149
+  const quoteError = validateQuoteBalance(query);
+  if (quoteError) {
+    console.error(pc.red(`Error: ${quoteError}`));
     process.exit(1);
   }
 

--- a/src/regex.test.ts
+++ b/src/regex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildApiQuery, escapeApiTerm, isRegexQuery } from "./regex.ts";
+import { buildApiQuery, escapeApiTerm, isRegexQuery, validateQuoteBalance } from "./regex.ts";
 
 // ─── isRegexQuery ─────────────────────────────────────────────────────────────
 
@@ -315,5 +315,49 @@ describe("buildApiQuery — warn cases", () => {
     expect(r.warn).toBeDefined();
     // The raw token should appear in warn for easy identification.
     expect(r.warn).toContain("/[/");
+  });
+});
+
+describe("validateQuoteBalance (issue #149)", () => {
+  it("returns null for a query with no quotes", () => {
+    expect(validateQuoteBalance("useFeatureFlag")).toBeNull();
+  });
+
+  it("returns null for a balanced two-quote phrase", () => {
+    expect(validateQuoteBalance('"feature flag"')).toBeNull();
+  });
+
+  it("returns an error for '\"react\": ' style queries with an odd number of unescaped quotes", () => {
+    // Regression: github-code-search '"react": "' --org fulll returned a raw
+    // GitHub 422 ERROR_TYPE_QUERY_PARSING_FATAL — this must now be caught locally.
+    const err = validateQuoteBalance('"react": "');
+    expect(err).not.toBeNull();
+    expect(err).toContain("Unbalanced double quotes");
+  });
+
+  it("error message includes a corrected example using double escaping", () => {
+    const err = validateQuoteBalance('"react": "');
+    expect(err).toContain('\\"react\\"');
+  });
+
+  it("returns null when escaped quotes make the query GitHub-valid", () => {
+    // The shell must deliver the literal backslash-quote sequence for this to work
+    // (single-quoted at the shell level): github-code-search '"\"react\": \""' --org myorg
+    expect(validateQuoteBalance('"\\"react\\": \\""')).toBeNull();
+  });
+
+  it("returns null for regex queries (validated separately by buildApiQuery)", () => {
+    // The /pattern/ token itself may contain an odd count of literal quote
+    // characters (e.g. "react":\s*" has 3) without being invalid GitHub syntax —
+    // extractApiTerm already escapes it correctly, so this check does not apply.
+    expect(validateQuoteBalance('/"react":\\s*"[~^]?[0-9]/')).toBeNull();
+  });
+
+  it("returns an error for three unescaped quotes in a row", () => {
+    expect(validateQuoteBalance('"""')).not.toBeNull();
+  });
+
+  it("returns null for four unescaped quotes (two balanced phrases)", () => {
+    expect(validateQuoteBalance('"foo" "bar"')).toBeNull();
   });
 });

--- a/src/regex.test.ts
+++ b/src/regex.test.ts
@@ -346,11 +346,27 @@ describe("validateQuoteBalance (issue #149)", () => {
     expect(validateQuoteBalance('"\\"react\\": \\""')).toBeNull();
   });
 
-  it("returns null for regex queries (validated separately by buildApiQuery)", () => {
+  it("only excludes the /pattern/ token itself, not the rest of a mixed query (issue #149 review)", () => {
     // The /pattern/ token itself may contain an odd count of literal quote
     // characters (e.g. "react":\s*" has 3) without being invalid GitHub syntax —
-    // extractApiTerm already escapes it correctly, so this check does not apply.
+    // extractApiTerm already escapes it correctly, so this check does not apply
+    // to a query made up of only a regex token.
     expect(validateQuoteBalance('/"react":\\s*"[~^]?[0-9]/')).toBeNull();
+  });
+
+  it("still catches an unbalanced stray quote outside the regex token in a mixed query", () => {
+    // Regression: validateQuoteBalance previously bailed out entirely for any
+    // query containing a /pattern/ token (via isRegexQuery), so a stray
+    // unescaped quote in the surrounding qualifiers/text (outside the token)
+    // was never caught and could still reach the GitHub API unbalanced.
+    const err = validateQuoteBalance('filename:package.json /"react":\\s*"[~^]?[0-9]/ "oops');
+    expect(err).not.toBeNull();
+    expect(err).toContain("Unbalanced double quotes");
+  });
+
+  it("does not flag a mixed query with balanced quotes outside the regex token", () => {
+    const err = validateQuoteBalance('"feature flag" /TODO|FIXME|HACK/');
+    expect(err).toBeNull();
   });
 
   it("returns an error for three unescaped quotes in a row", () => {

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -13,6 +13,49 @@ export function isRegexQuery(q: string): boolean {
 }
 
 /**
+ * Returns true when the `"` at `index` in `s` is escaped, i.e. preceded by an
+ * odd number of consecutive backslashes (GitHub's `\"` escape sequence).
+ */
+function isEscapedQuote(s: string, index: number): boolean {
+  let backslashes = 0;
+  let i = index - 1;
+  while (i >= 0 && s[i] === "\\") {
+    backslashes++;
+    i--;
+  }
+  return backslashes % 2 === 1;
+}
+
+/**
+ * Validates that a plain-text (non-regex) query has a balanced number of
+ * unescaped `"` characters, as required by GitHub's query syntax — an odd
+ * count is rejected by the API with an opaque
+ * `ERROR_TYPE_QUERY_PARSING_FATAL` 422 error.
+ *
+ * Returns `null` when the query is valid (including regex queries, whose
+ * `/pattern/` token is validated separately by `buildApiQuery`). Returns a
+ * human-readable error message — including a corrected example using
+ * GitHub's documented double-escaping syntax — when the query would be
+ * rejected by the API. See issue #149.
+ */
+export function validateQuoteBalance(query: string): string | null {
+  if (isRegexQuery(query)) return null;
+
+  let unescapedCount = 0;
+  for (let i = 0; i < query.length; i++) {
+    if (query[i] === '"' && !isEscapedQuote(query, i)) unescapedCount++;
+  }
+  if (unescapedCount % 2 === 0) return null;
+
+  return (
+    `Unbalanced double quotes in query: ${JSON.stringify(query)}. ` +
+    "GitHub rejects this with a query parsing error. " +
+    "To search for a literal quote character, escape it for both your shell and GitHub, " +
+    'e.g.: github-code-search \'"\\"react\\": \\""\' --org myorg'
+  );
+}
+
+/**
  * Given a raw query string (possibly mixing GitHub qualifiers and a /regex/flags
  * token), returns:
  *

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -27,23 +27,32 @@ function isEscapedQuote(s: string, index: number): boolean {
 }
 
 /**
- * Validates that a plain-text (non-regex) query has a balanced number of
- * unescaped `"` characters, as required by GitHub's query syntax — an odd
- * count is rejected by the API with an opaque
- * `ERROR_TYPE_QUERY_PARSING_FATAL` 422 error.
+ * Validates that a plain-text query has a balanced number of unescaped `"`
+ * characters, as required by GitHub's query syntax — an odd count is
+ * rejected by the API with an opaque `ERROR_TYPE_QUERY_PARSING_FATAL` 422
+ * error.
  *
- * Returns `null` when the query is valid (including regex queries, whose
- * `/pattern/` token is validated separately by `buildApiQuery`). Returns a
- * human-readable error message — including a corrected example using
- * GitHub's documented double-escaping syntax — when the query would be
- * rejected by the API. See issue #149.
+ * Quotes inside a `/pattern/` regex token are excluded from this check: they
+ * are handled separately by `buildApiQuery`/`extractApiTerm`, which escapes
+ * them for the API term. Only the token itself is excluded, not the rest of
+ * the query — a mixed query like `filename:package.json /regex/ "oops` must
+ * still be caught, since the stray quote outside the token would otherwise
+ * reach the GitHub API unbalanced. See issue #149.
+ *
+ * Returns `null` when the query is valid. Returns a human-readable error
+ * message — including a corrected example using GitHub's documented
+ * double-escaping syntax — when the query would be rejected by the API.
  */
 export function validateQuoteBalance(query: string): string | null {
-  if (isRegexQuery(query)) return null;
+  const token = extractRegexToken(query);
+  const outsideToken =
+    token === null
+      ? query
+      : query.slice(0, token.index) + query.slice(token.index + token.raw.length);
 
   let unescapedCount = 0;
-  for (let i = 0; i < query.length; i++) {
-    if (query[i] === '"' && !isEscapedQuote(query, i)) unescapedCount++;
+  for (let i = 0; i < outsideToken.length; i++) {
+    if (outsideToken[i] === '"' && !isEscapedQuote(outsideToken, i)) unescapedCount++;
   }
   if (unescapedCount % 2 === 0) return null;
 


### PR DESCRIPTION
### What does this PR do?

Closes #149.

Plain-text (non-regex) queries with raw double quotes could silently produce false positives (GitHub strips balanced quotes and treats adjacent punctuation as separate terms) or an opaque `422 ERROR_TYPE_QUERY_PARSING_FATAL` from the API when the quote count was odd.

`validateQuoteBalance()` in `src/regex.ts` now detects an odd number of unescaped double quotes in a plain-text query before any network call, and `github-code-search.ts` exits early with an actionable message that includes a corrected example using GitHub's documented double-escaping syntax (shell and GitHub). Regex `/pattern/` queries are unaffected, they are validated separately by `buildApiQuery`/`extractApiTerm` (see #147). Balanced-quote queries, including legitimate exact-phrase queries like `"feature flag"`, keep working unchanged.

### How did you verify your code works?

- Added unit tests in `src/regex.test.ts` covering balanced, unbalanced, escaped, and regex-bypass cases.
- Ran the full suite, lint, format check and knip; all green.
- Built the binary and confirmed the reported unbalanced-quote query now fails locally with a clear message instead of the previous raw GitHub 422, and that a legitimate two-quote phrase query still works unchanged.
