### PR TITLE
Fix systematic exit delay after search output (interactive + non-interactive)

### DIFF
--- a/github-code-search.ts
+++ b/github-code-search.ts
@@ -465,15 +465,22 @@ async function searchAction(
     // Race against a 2 s timeout so slow networks never delay the exit.
     // Fix: use AbortController so the in-flight fetch is actually cancelled on timeout.
     const updateAbortController = new AbortController();
+    // Fix: the losing Promise.race branch's timer is never cleared, and by default
+    // keeps the process alive until it fires — causing a ~2 s exit delay on every
+    // non-interactive run even when checkForUpdate resolves instantly. unref() lets
+    // the process exit as soon as the real work is done; clearTimeout on the winning
+    // path avoids a stray abort() firing after we've already moved on.
+    let updateCheckTimer!: ReturnType<typeof setTimeout>;
     const latestTag = await Promise.race([
       checkForUpdate(VERSION, GITHUB_TOKEN, updateAbortController.signal),
-      new Promise<null>((res) =>
-        setTimeout(() => {
+      new Promise<null>((res) => {
+        updateCheckTimer = setTimeout(() => {
           updateAbortController.abort();
           res(null);
-        }, 2000),
-      ),
+        }, 2000).unref();
+      }),
     ]).catch(() => null);
+    clearTimeout(updateCheckTimer);
     if (latestTag) {
       const w = 55;
       // Fix: compute all widths from totalWidth so corners always align.

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -308,6 +308,9 @@ export async function runInteractive(
     if (statsDebounceTimer !== null) clearTimeout(statsDebounceTimer);
     process.stdin.setRawMode(false);
     process.off("SIGWINCH", onResize);
+    // Unref stdin so the pending `for await` read can't keep the event loop
+    // alive while breaking out of the loop awaits the stream's teardown.
+    process.stdin.unref();
     // Set flag to break out of the event loop and allow stdout buffer to flush
     // before process termination. process.exit() may terminate too early.
     shouldExit = true;
@@ -659,6 +662,9 @@ export async function runInteractive(
       process.stdout.write(ANSI_CLEAR);
       process.stdin.setRawMode(false);
       process.off("SIGWINCH", onResize);
+      // Unref stdin so the pending `for await` read can't keep the event loop
+      // alive while breaking out of the loop awaits the stream's teardown.
+      process.stdin.unref();
       if (statsDebounceTimer !== null) clearTimeout(statsDebounceTimer);
       console.log(
         buildOutput(groups, query, org, excludedRepos, excludedExtractRefs, format, outputType, {


### PR DESCRIPTION
### What does this PR do?

Fixes a systematic delay between the moment the final output is printed and the moment the process actually returns control to the shell — noticeable in both interactive and non-interactive (`--no-interactive` / CI) mode.

**Root cause 1 — interactive mode (`src/tui.ts`)**

Keyboard input is read via `for await (const chunk of process.stdin)`. Breaking out of that loop (on `Enter`, `q`, or Ctrl+C) forces the JS engine to await the async iterator's implicit `return()`, which destroys the underlying `Readable` and waits for its `'close'` event before the `break` actually completes. The output is already printed by then (`console.log` runs before the `break`), so the user sees the result immediately but the shell prompt only comes back once that stream teardown resolves.

Fix: call `process.stdin.unref()` right after `setRawMode(false)` in both exit paths. An unref'd handle can no longer keep the event loop alive, so the process can exit as soon as the teardown starts instead of waiting for it to fully settle.

**Root cause 2 — non-interactive mode (`github-code-search.ts`)**

The post-output "check for update" step races `checkForUpdate()` against a 2 s timeout via `Promise.race`:

```ts
await Promise.race([
  checkForUpdate(...),
  new Promise((res) => setTimeout(() => { ...; res(null); }, 2000)),
]);
```

The losing branch's `setTimeout` is never cleared. Node/Bun timers are ref'd by default, so even when `checkForUpdate()` wins the race in a few hundred ms, the orphaned 2 s timer keeps the process alive until it actually fires — a near-constant ~2 s delay on every CI/`--no-interactive` run.

Fix: `.unref()` the timer so it can't keep the process alive on its own, and `clearTimeout` it once the race settles (avoids a stray `abort()` firing after the flow has already moved on). The 2 s network cap behaviour is unchanged.

### How did you verify your code works?

- `bun run lint` — zero errors
- `bun run format:check` — no diff
- `bun test` — 871 tests pass, 0 failures, no regressions
- Manual repro/verification (not unit-testable — `tui.ts` and the CLI entry point are side-effectful, per `AGENTS.md`):
  - Interactive: run a search, press `Enter` to confirm selection — shell prompt now returns immediately instead of after a noticeable pause.
  - Non-interactive: run with `--no-interactive` (or `CI=true`) — process now exits right after printing output instead of ~2 s later.
